### PR TITLE
Add startup pattern decision guide and window management improvements

### DIFF
--- a/src/content/docs/architecture/loading-screen.mdx
+++ b/src/content/docs/architecture/loading-screen.mdx
@@ -235,6 +235,23 @@ sequenceDiagram
   Window-->>User: Real content visible
 ```
 
+## Choosing the Right Startup Pattern
+
+Different apps have different startup needs. This table helps you pick the right approach:
+
+| Scenario                                                       | Recommended pattern                                                          | Where documented                                                                                      |
+| -------------------------------------------------------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| App wraps a dev server / sidecar with 5-30s startup            | Bundled loading HTML via `WebviewUrl::default()` + background polling        | This page                                                                                             |
+| SPA that just needs to avoid white flash on launch             | Hidden window + `show()` on `PageLoadEvent::Finished`                        | [Window Creation and Lifecycle](/pj/zudo-tauri/docs/rust-backend/window-management/)                   |
+| App has blocking init (DB migrations, auth, first-run setup)   | Separate splash window (frameless, transparent)                              | [Window Creation and Lifecycle](/pj/zudo-tauri/docs/rust-backend/window-management/)                   |
+| Dev mode inline loading page                                   | `data:` URL (requires `webview-data-url` cargo feature)                      | [Window Creation and Lifecycle](/pj/zudo-tauri/docs/rust-backend/window-management/)                   |
+
+<Tip>
+
+The official Tauri v2 splashscreen guide recommends showing the main window quickly with in-app loading state over using a separate splash window, whenever possible.
+
+</Tip>
+
 ## The Refresh Pattern
 
 When implementing a refresh command (Cmd+R), you can reuse the same loading-then-navigate pattern:

--- a/src/content/docs/claude-skills/tauri-wisdom.mdx
+++ b/src/content/docs/claude-skills/tauri-wisdom.mdx
@@ -1,13 +1,13 @@
 ---
 title: tauri-wisdom
-description: Search and reference documentation from the zudo-tauri project. Use when answering questions about zudo-tauri features, configuration, components, or usage patterns.
+description: Search and reference documentation from the takazudo-zudo-tauri project. Use when answering questions about takazudo-zudo-tauri features, configuration, components, or usage patterns.
 sidebar_label: tauri-wisdom
 generated: true
 ---
 
-# zudo-tauri Documentation Reference
+# takazudo-zudo-tauri Documentation Reference
 
-Look up documentation from the zudo-tauri project.
+Look up documentation from the takazudo-zudo-tauri project.
 Documentation base path: `/Users/takazudo/repos/wisdom/zudo-tauri/src/content/docs`
 
 ## Mode Detection

--- a/src/content/docs/rust-backend/window-management.mdx
+++ b/src/content/docs/rust-backend/window-management.mdx
@@ -79,6 +79,12 @@ When creating windows programmatically, keep the `"windows"` array in `tauri.con
 
 </Note>
 
+<Warning>
+
+Watch out for the **visibility gap**: if you close the splash before the main window is visible, the user briefly sees no window at all. Either keep the splash open until the main window is ready to show, or skip the splash entirely and use a hidden main window with `PageLoadEvent::Finished` or a delayed `show()`.
+
+</Warning>
+
 ## Main window with dev server polling
 
 In development, the Vite dev server may not be ready when the window is created. The pattern is: show a loading page immediately, then navigate to the dev server once it responds.
@@ -147,7 +153,16 @@ pub fn create_main_window(
         });
     }
 
-    // Show after a short delay
+    // Belt-and-suspenders: show on focus event OR after delay
+    let win_clone = window.clone();
+    window.on_window_event(move |event| {
+        if let tauri::WindowEvent::Focused(true) = event {
+            if !win_clone.is_visible().unwrap_or(false) {
+                let _ = win_clone.show();
+            }
+        }
+    });
+
     let win = window.clone();
     std::thread::spawn(move || {
         std::thread::sleep(std::time::Duration::from_millis(200));
@@ -194,6 +209,12 @@ fn wait_for_dev_server(url: &str, timeout_secs: u64) -> bool {
 The `data:` URL approach shown above requires the `webview-data-url` cargo feature to be enabled in `Cargo.toml`. Without it, the webview will fail to load data URLs. Bundled HTML files (`WebviewUrl::default()` or `WebviewUrl::App(...)`) are generally preferred for maintainability -- they are easier to edit, can include external assets, and do not require extra feature flags.
 
 </Warning>
+
+<Tip>
+
+The `on_window_event(Focused)` handler acts as a safety net -- if the timed `show()` fires before the webview finishes rendering, the Focused event will catch it. Combining both gives more reliable behavior than either alone.
+
+</Tip>
 
 ## Anti-flash: show on page load
 

--- a/src/content/docs/rust-backend/window-management.mdx
+++ b/src/content/docs/rust-backend/window-management.mdx
@@ -189,6 +189,54 @@ fn wait_for_dev_server(url: &str, timeout_secs: u64) -> bool {
 
 </Tip>
 
+<Warning>
+
+The `data:` URL approach shown above requires the `webview-data-url` cargo feature to be enabled in `Cargo.toml`. Without it, the webview will fail to load data URLs. Bundled HTML files (`WebviewUrl::default()` or `WebviewUrl::App(...)`) are generally preferred for maintainability -- they are easier to edit, can include external assets, and do not require extra feature flags.
+
+</Warning>
+
+## Anti-flash: show on page load
+
+For apps that load bundled frontend (no server polling needed), the simplest way to prevent white flash is to start hidden and show on first page load:
+
+```rust
+use tauri::webview::PageLoadEvent;
+
+tauri::Builder::default()
+  .on_page_load(|webview, payload| {
+    if webview.label() == "main"
+      && matches!(payload.event(), PageLoadEvent::Finished)
+    {
+      let _ = webview.window().show();
+    }
+  })
+```
+
+This replaces the manual 200ms delay approach and is more reliable because it waits for actual content to render.
+
+<Note>
+
+Combine this with `.visible(false)` on the window builder so the window starts hidden and only appears once the page has fully loaded.
+
+</Note>
+
+<Note>
+
+If you control window visibility from the frontend JavaScript API instead of from Rust, you must grant these capabilities in your Tauri v2 configuration:
+
+```json
+{
+  "permissions": [
+    "core:window:allow-show",
+    "core:window:allow-hide"
+  ]
+}
+```
+
+Without these permissions, calls to `appWindow.show()` or `appWindow.hide()` from the frontend will silently fail.
+
+</Note>
+
 ## macOS: suppress press-and-hold accent menu
 
 macOS shows an accent character popup when you press and hold a key. This interferes with apps that use key-repeat (text editors, terminal emulators). Suppress it in `setup()`:
@@ -324,8 +372,14 @@ flowchart TD
 
 1. **Keep `"windows": []` empty in tauri.conf.json** when creating windows programmatically
 2. **Start windows hidden** and show after content is ready to avoid white flash
-3. **Use `data:` URLs for loading pages** -- no need for bundled HTML files
+3. **Use `data:` URLs for loading pages** -- no need for bundled HTML files (but note the `webview-data-url` feature flag requirement)
 4. **Poll dev server with TCP connect** -- faster than HTTP requests
 5. **Always clean up child processes** on window destroy
 6. **Use `on_navigation` to control link behavior** -- open external links in the default browser
 7. **Platform-specific code** goes behind `#[cfg(target_os = "macos")]` guards
+
+<Warning>
+
+If you use `tauri-plugin-window-state`, it may restore the persisted `VISIBLE` state on launch, which fights with the hidden-then-show pattern. You need to explicitly exclude the visibility flag from being persisted, or the plugin will show the window before your code is ready to display content.
+
+</Warning>


### PR DESCRIPTION
## Summary
- Add a startup pattern decision guide table to `loading-screen.mdx` helping readers choose between four different startup approaches
- Enhance `window-management.mdx` with anti-flash pattern, data URL warnings, window-state plugin caveats, and v2 permissions info

## Changes

### `loading-screen.mdx`
- New "Choosing the Right Startup Pattern" section with a decision table covering: bundled loading HTML + polling, hidden window + PageLoadEvent, separate splash window, and data URL approaches
- Each row links to the relevant documentation page
- Tip about the official Tauri v2 splashscreen recommendation

### `window-management.mdx`
- New "Anti-flash: show on page load" section with `PageLoadEvent::Finished` pattern as a more reliable alternative to the 200ms delay
- Note about combining with `.visible(false)` on the window builder
- Note about Tauri v2 permissions (`core:window:allow-show`, `core:window:allow-hide`) needed for frontend JS visibility control
- Warning about `data:` URLs requiring the `webview-data-url` cargo feature
- Warning about `tauri-plugin-window-state` potentially restoring visible state and conflicting with the hidden-then-show pattern
- Updated key takeaway #3 to mention the feature flag requirement

## Test Plan
- [x] MDX formatting check passed (`pnpm format:md`)
- [x] Full site build passed (`pnpm build`)
- [x] CI checks passed (Type Check + Build Site)