### PR TITLE
Rename repo to zudo-tauri-wisdom

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -121,13 +121,13 @@ jobs:
           RUN_ID: ${{ github.run_id }}
         run: |
           if [ "$DEPLOY_RESULT" = "success" ]; then
-            STATUS="zudo-tauri deploy succeeded!"
+            STATUS="zudo-tauri-wisdom deploy succeeded!"
           elif [ "$BUILD_SITE_RESULT" = "failure" ]; then
-            STATUS="zudo-tauri deploy failed (site build)"
+            STATUS="zudo-tauri-wisdom deploy failed (site build)"
           elif [ "$DEPLOY_RESULT" = "failure" ]; then
-            STATUS="zudo-tauri deploy failed (deploy)"
+            STATUS="zudo-tauri-wisdom deploy failed (deploy)"
           else
-            STATUS="zudo-tauri deploy cancelled"
+            STATUS="zudo-tauri-wisdom deploy cancelled"
           fi
 
           COMMIT_MSG=$(echo "$RAW_COMMIT_MSG" | head -1 | sed 's/"/\\"/g')

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# zudo-tauri
+# zudo-tauri-wisdom
 
 Takazudo's Tauri v2 dev notes, built with zudo-doc (Astro, MDX, Tailwind CSS v4).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# zudo-tauri
+# zudo-tauri-wisdom
 
 Takazudo's personal Tauri v2 dev notes. Not official Tauri documentation.
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "zudo-tauri",
+  "name": "zudo-tauri-wisdom",
   "version": "0.0.1",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary
- Update package name, README heading, CLAUDE.md heading, and IFTTT notification messages to reflect the repo rename from `zudo-tauri` to `zudo-tauri-wisdom`
- Git remote URL updated to new GitHub repo URL
- Symlink baking script re-applied to reflect new directory path

## Note
Deployment paths (`/pj/zudo-tauri/`) and Cloudflare Pages project names are intentionally unchanged — only repo identity references updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)