### PR TITLE
docs: capture CCResDoc launch-fix Tauri findings (claude-settings#44)

### DIFF
--- a/src/content/docs-ja/architecture/loading-screen.mdx
+++ b/src/content/docs-ja/architecture/loading-screen.mdx
@@ -280,3 +280,137 @@ fn do_refresh(app_handle: &AppHandle) {
 ```
 
 この処理は、古い sidecar を kill し、ポートをクリーンアップし、新しい sidecar を起動し、準備完了を待ち、その後ナビゲートする。リフレッシュのタイムアウト（15秒）は初回起動のタイムアウト（120秒）より短い。これはサーバーが2回目以降の起動ではより速く起動することが期待されるためである。
+
+## エラー状態とリトライ
+
+「スピナー+テキスト」だけの最小ローディングページはハッピーパスでは機能するが、sidecar が既に死んでいたり、ビルドがストールしている状況ではユーザーに嘘をつくことになる。sidecar が健全にビルドしているのか、クラッシュして戻ってこないのか、どちらの場合も同じスピナーが見える。
+
+次のレベルのパターンは、ローディングページをエラーパネルも兼ねるものにすることだ。スピナーはハッピーパスで、非表示のエラーパネルがバックエンドから発火される `launch-error` イベントをリスンし、リトライボタン付きの操作可能な状態に切り替わる。
+
+### バックエンドの契約
+
+Rust 側は[準備完了ポーリングで sidecar の死亡やタイムアウトを検出した](./process-lifecycle.mdx#準備完了ループでの-sidecar-の死亡検出)際に、ナビゲートする代わりに `launch-error` イベントを発火する:
+
+```rust
+// イベントペイロードの形
+// { reason: "timeout" | "sidecar_exited", logPath: "/path/to/sidecar.log" }
+```
+
+対応する `retry_launch` コマンドがリスタートをトリガーするので、フロントエンドはリトライボタンを用意できる:
+
+```rust
+#[tauri::command]
+fn retry_launch(app_handle: AppHandle) {
+    // バックグラウンドスレッドで実行する -- IPC スレッドを絶対にブロックしない。
+    // do_refresh() は失敗時に launch-error を再発火するため、
+    // リトライが再度失敗した場合も自然に UI がエラー状態へ戻る。
+    thread::spawn(move || {
+        do_refresh(&app_handle);
+    });
+}
+```
+
+<Warning>
+
+長時間かかるリスタートを IPC スレッド上でインラインに走らせてはならない。Tauri の IPC ランタイムは小さなスレッドプールでコマンドをディスパッチする。sidecar を起動して 15 秒の準備完了を待ってから return する `retry_launch` は、その時間帯、他のコマンドをすべてブロックする。処理はバックグラウンドの `std::thread` にスポーンし、すぐに return すること。
+
+</Warning>
+
+### フロントエンドのパネル
+
+ローディング HTML に非表示のエラーパネルを追加する。インライン CSS と JS のみで構成する -- このページはバンドル済みでバンドラがなく、import は選択肢にない:
+
+```html
+<!-- frontend/index.html (省略版) -->
+<body>
+  <div id="spinner" class="spinner"></div>
+  <div id="long-hint" class="sub" hidden>Taking longer than usual…</div>
+
+  <div id="error-panel" hidden>
+    <h2>Could not start the documentation server</h2>
+    <p id="error-reason"></p>
+    <p class="log"><code id="error-log-path"></code></p>
+    <button id="retry">Retry</button>
+    <button id="copy-log">Copy log path</button>
+  </div>
+
+  <script>
+    const { event, core } = window.__TAURI__;
+
+    event.listen("launch-error", ({ payload }) => {
+      document.getElementById("spinner").hidden = true;
+      document.getElementById("long-hint").hidden = true;
+      document.getElementById("error-reason").textContent =
+        payload.reason === "sidecar_exited"
+          ? "The background server exited before becoming ready."
+          : "The server took too long to respond.";
+      document.getElementById("error-log-path").textContent = payload.logPath;
+      document.getElementById("error-panel").hidden = false;
+    });
+
+    document.getElementById("retry").addEventListener("click", () => {
+      document.getElementById("error-panel").hidden = true;
+      document.getElementById("spinner").hidden = false;
+      core.invoke("retry_launch");
+    });
+
+    document.getElementById("copy-log").addEventListener("click", () => {
+      navigator.clipboard.writeText(
+        document.getElementById("error-log-path").textContent,
+      );
+    });
+
+    // ベルト・アンド・サスペンダーズ: 20 秒経ってもローディングページのまま
+    // だったら、通常より時間がかかっていることをほのめかす。エラーとは別物 --
+    // スピナーは回ったままで、パネルは非表示のまま。
+    setTimeout(() => {
+      if (document.getElementById("error-panel").hidden) {
+        document.getElementById("long-hint").hidden = false;
+      }
+    }, 20_000);
+  </script>
+</body>
+```
+
+<Note>
+
+20 秒の「時間がかかっています」ヒントは、エラーパネルとは視覚的に区別する。初回の遅いビルド（大きな依存関係インストール、cargo キャッシュが冷えている等）のユーザーに、失敗シグナルを誤って送らずに状況を伝えるのが狙いだ。エラーパネルはバックエンドが実際に `launch-error` を発火したときだけ表示する。
+
+</Note>
+
+### バンドルページの 2 つの前提条件
+
+`frontend/index.html` はバンドル済みでバンドラがないため、Tauri API に到達する手段は `window.__TAURI__` しかない。設定で 2 つのディテールを揃える必要がある:
+
+1. **`tauri.conf.json` の `withGlobalTauri: true`** -- Tauri v2 ではデフォルトが `false` で、`window.__TAURI__` そのものが存在しない状態になる。これを忘れると `event.listen` と `core.invoke` は無言で何もせず、パネルの配線が成立しない。
+2. **`core:default` ケイパビリティ** -- `event:listen` とカスタムコマンドの invoke の両方がこれでカバーされている。追加のケイパビリティ付与は不要。
+
+設定の詳細は [IPC → バンドル済みローディングページからの IPC 呼び出し](../frontend/ipc-commands.mdx#バンドル済みローディングページからの-ipc-呼び出し)を参照。
+
+### シーケンス
+
+```mermaid
+sequenceDiagram
+  participant User as ユーザー
+  participant Rust as Rust メイン
+  participant Window as ローディングページ
+  participant Sidecar
+
+  Rust->>Sidecar: spawn_sidecar()
+  Rust->>Window: ローディングページ表示
+  Note over Window: スピナー + "Starting…"
+
+  alt sidecar が早期に死亡
+    Sidecar--xRust: /___ready が 200 を返す前に終了
+    Rust->>Window: emit("launch-error", { reason: "sidecar_exited" })
+    Window-->>User: エラーパネル + リトライボタン
+    User->>Window: リトライをクリック
+    Window->>Rust: invoke("retry_launch")
+    Rust->>Sidecar: バックグラウンドスレッドで do_refresh()
+  else 健全だが遅い
+    Note over Window: 20秒後、"Taking longer than usual…"
+    Sidecar-->>Rust: /___ready → 200
+    Rust->>Window: navigate(server_url)
+    Window-->>User: 実コンテンツ
+  end
+```

--- a/src/content/docs-ja/architecture/process-lifecycle.mdx
+++ b/src/content/docs-ja/architecture/process-lifecycle.mdx
@@ -338,6 +338,102 @@ sequenceDiagram
   Rust->>Rust: app_handle.exit(0)
 ```
 
+## 準備完了ループでの sidecar の死亡検出
+
+素朴な準備完了ループは `/___ready` をポーリングし、`Ready` を返すかタイムアウトで諦めるだけである。sidecar が健全なときはそれで動くが、sidecar がすでに死んでいる場合 -- 典型的には初回起動時に `node_modules/` が存在しないケース -- タイムアウト時間をフルに消費してしまう。ユーザーは 120 秒間ローディングページを見せられ、その後アプリは死んだポートにナビゲートする。
+
+解決策は、子プロセスがすでに終了している場合に `wait_for_ready` が短絡的に抜けられるようにすることだ。sidecar ハンドルを渡し、各ポーリング毎に `Child::try_wait()` を呼ぶ:
+
+```rust
+pub enum ReadyResult {
+    Ready,
+    Timeout,
+    SidecarExited { code: Option<i32> },
+}
+
+pub fn wait_for_ready(
+    sidecar: &Arc<Mutex<Option<Sidecar>>>,
+    timeout: Duration,
+) -> ReadyResult {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        // ロックは狭いスコープで取得する -- curl 呼び出しをまたいで保持してはならない。
+        if let Ok(mut guard) = sidecar.lock() {
+            if let Some(s) = guard.as_mut() {
+                match s.child.try_wait() {
+                    Ok(Some(status)) => {
+                        return ReadyResult::SidecarExited {
+                            code: status.code(),
+                        };
+                    }
+                    Ok(None) => {} // まだ実行中
+                    Err(e) => log(&format!("try_wait error: {e}")),
+                }
+            }
+        }
+
+        let code = check_ready();
+        if code != "000" && code != "err" {
+            thread::sleep(Duration::from_secs(1));
+            return ReadyResult::Ready;
+        }
+        thread::sleep(Duration::from_secs(1));
+    }
+    ReadyResult::Timeout
+}
+```
+
+押さえるべき点は 3 つある:
+
+- **`try_wait()` は軽い。** `waitpid(WNOHANG)` 1 回分のシステムコールで、子プロセスが走っている間は `Ok(None)` を、終了した時点で `Ok(Some(status))` を返す。1 Hz のポーリングで呼んでも問題ない。
+- **ミューテックスのロックは狭いスコープで。** ロック取得 → `try_wait()` → `curl` を実行する前にガードを破棄する。ネットワーク呼び出しをまたいでガードを保持してしまうと、同じミューテックスを必要とするリフレッシュや終了などのパスをブロックする。
+- **両方の呼び出し元で `ReadyResult` を分岐処理する。** `setup()` の初回起動と `do_refresh()` のどちらも enum を消費し、死んだポートへナビゲートする代わりに `launch-error` イベントを発火する。フロントエンド側は[ローディング画面 → エラー状態とリトライ](./loading-screen.mdx#エラー状態とリトライ)を参照。
+
+<Warning>
+
+`curl` の呼び出しをまたいで `Mutex<Option<Sidecar>>` のガードを保持してはならない。ロックを握ったままの 1 秒の curl は、同じミューテックスに触れる必要があるリフレッシュやリトライ、ウィンドウクローズのイベントをすべて止めるのに十分な時間である。ガードは `try_wait()` の読み取りだけをカバーするスコープにする。
+
+</Warning>
+
+### launch-error イベントの発火
+
+`wait_for_ready` が `Timeout` または `SidecarExited` を返したら、死んだ URL へナビゲートする代わりに Tauri イベントを発火する。ローディングページがそれをリスンし、エラー状態に切り替わる（loading-screen.mdx 参照）。
+
+```rust
+use tauri::{AppHandle, Emitter, Manager};
+
+fn emit_launch_error(app_handle: &AppHandle, reason: &str) {
+    if let Some(w) = app_handle.get_webview_window("main") {
+        let _ = w.emit(
+            "launch-error",
+            serde_json::json!({
+                "reason": reason,
+                "logPath": sidecar_log_path().to_string_lossy(),
+            }),
+        );
+    }
+}
+
+// setup() / do_refresh() 内:
+match wait_for_ready(&state.sidecar, Duration::from_secs(120)) {
+    ReadyResult::Ready => {
+        let _ = w.navigate(server_url().parse().unwrap());
+    }
+    ReadyResult::Timeout => emit_launch_error(&handle, "timeout"),
+    ReadyResult::SidecarExited { .. } => {
+        emit_launch_error(&handle, "sidecar_exited");
+    }
+}
+```
+
+<Tip>
+
+`tauri::Emitter` は v2 のトレイトで、`AppHandle` と `WebviewWindow` の両方に `.emit()` を追加する。アプリハンドルからではなくウィンドウから emit することで、そのウィンドウのフロントエンドリスナーに狙って届けられる。
+
+`serde_json` は `tauri` 経由で推移的に入ってくるので、`dev-dependencies` から `dependencies` に昇格させてもコンパイル時間は変わらない。カスタム構造体を定義する代わりに `serde_json::json!` でペイロードを組み立てられるようになる。
+
+</Tip>
+
 ## ロギング
 
 アプリ自体のライフサイクルイベントと sidecar の出力は、別々のファイルに記録すべきである:

--- a/src/content/docs-ja/frontend/ipc-commands.mdx
+++ b/src/content/docs-ja/frontend/ipc-commands.mdx
@@ -342,6 +342,75 @@ pub fn draft_read(
 
 これにより、コマンドはパラメータ処理に集中した薄いものになり、実際のロジックは複数のコマンドから呼び出し可能な再利用可能な関数に配置される。
 
+## バンドル済みローディングページからの IPC 呼び出し
+
+ラッパーアプリのバンドル済み `frontend/index.html`（ローディングページ）は、しばしばバンドラを持たない -- スピナーを表示して実際の開発サーバーにナビゲートするまでのごく短い時間のために `frontendDist` から配信されるプレーンな HTML である。このページからバックエンドのイベントを `listen` したり、カスタムコマンドを `invoke` する必要がある場合（[エラー状態のローディングページ](../architecture/loading-screen.mdx#エラー状態とリトライ)の `retry_launch` など）、Tauri JS SDK を `import` することはできない。唯一の選択肢は `window.__TAURI__` である。
+
+設定で 2 つのディテールを揃える必要がある。どちらも見落としやすい:
+
+### 1. `withGlobalTauri` を有効にする
+
+Tauri v2 では `app.withGlobalTauri` のデフォルトは `false`。これはつまり `window.__TAURI__` が webview 内にそもそも存在しないということで、`window.__TAURI__.event.listen` は `TypeError: Cannot read properties of undefined` になる。ページは無言で失敗する -- 例外を明示的にログに出していない限り、フロントエンドにエラーは現れない。
+
+```json
+// tauri.conf.json
+{
+  "app": {
+    "withGlobalTauri": true
+  }
+}
+```
+
+<Warning>
+
+これは典型的な「なぜイベントリスナーが動かないのか」の罠である。バンドル済みローディングページが `window.__TAURI__` を少しでも使っていて、かつ `withGlobalTauri: true` を明示的に設定していないなら、何も動かず、フロントエンドにはエラーも出ない。失敗が可視化されるようにページ冒頭で防御的ログを仕込むとよい:
+
+```js
+if (!window.__TAURI__) {
+  console.error("window.__TAURI__ missing — set withGlobalTauri: true");
+}
+```
+
+</Warning>
+
+### 2. `core:default` で既にカバーされている
+
+典型的なローディングページ（1 つのイベントをリスンし、1〜2 個のカスタムコマンドを invoke する）では、`capabilities/default.json` の `core:default` で十分である。`event:listen`、`event:unlisten`、そしてカスタム `#[tauri::command]` 関数が使う invoke の配線がすべて付与される。`core:allow-emit-to-any` のような広すぎる権限を先回りで付与してはいけない -- 必要ないし、webview が触れる面積を無用に広げるだけだ。
+
+```json
+// capabilities/default.json -- デフォルトから変更なし
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "default",
+  "windows": ["main"],
+  "permissions": ["core:default"]
+}
+```
+
+### グローバルの使い方
+
+この 2 点が揃っていれば、バンドル済みページから直接リスンと invoke ができる:
+
+```html
+<script>
+  const { event, core } = window.__TAURI__;
+
+  // バックエンドイベントをリスン
+  const unlisten = await event.listen("launch-error", ({ payload }) => {
+    // payload は Rust が Emitter::emit で送ったもの
+  });
+
+  // カスタムコマンドを invoke
+  await core.invoke("retry_launch");
+</script>
+```
+
+<Note>
+
+`window.__TAURI__.core.invoke` は `@tauri-apps/api/core` が再エクスポートしている ESM 版の `invoke` と同じ関数である。ペイロードのシリアライズも戻り値のデシリアライズも同一 -- バンドル済みページは劣化した API を掴まされるわけではなく、import スタイルが違うだけだ。
+
+</Note>
+
 ## 重要なポイント
 
 1. **すべてのコマンドを `generate_handler!` に登録する** -- コンパイル時チェックは存在しない
@@ -351,3 +420,4 @@ pub fn draft_read(
 5. **`.map_err(|e| format!(...))` を使用してすべてのエラー型を `String` に変換する**
 6. **フロントエンドに適したフィールド名のために `Serialize` を `serde(rename)` 付きで derive する**
 7. **コマンドは薄く保つ** -- 内部ヘルパー関数に委譲する
+8. **バンドル済みローディングページには `withGlobalTauri: true` が必要** -- そうでなければ `window.__TAURI__` は無言で存在しない

--- a/src/content/docs-ja/recipes/doc-viewer-app.mdx
+++ b/src/content/docs-ja/recipes/doc-viewer-app.mdx
@@ -43,14 +43,16 @@ const PNPM_CMD: &str = "dev";
 
 本番モードでは、アプリはユーザーのシステム上で `pnpm` バイナリを見つける必要がある。GUI アプリはユーザーのシェル `PATH` を継承しないため、単に `pnpm` を呼び出すだけでは動作しない。
 
-戦略は、まずハードコードされた既知のパスを確認し、次に `which` にフォールバックすることである。
+戦略は、まずハードコードされた既知のパス（バージョンマネージャのシムを含む）を確認し、次に `which` にフォールバックすることである。
 
 ```rust
 fn find_pnpm() -> Option<PathBuf> {
     // Check well-known installation paths first
+    let home = std::env::var("HOME").ok()?;
     let candidates = [
-        "/opt/homebrew/bin/pnpm",
-        "/usr/local/bin/pnpm",
+        "/opt/homebrew/bin/pnpm".to_string(),  // Apple Silicon Homebrew
+        "/usr/local/bin/pnpm".to_string(),     // Intel Homebrew
+        format!("{home}/.volta/bin/pnpm"),     // Volta シム
     ];
     for p in &candidates {
         let path = PathBuf::from(p);
@@ -78,7 +80,7 @@ fn find_pnpm() -> Option<PathBuf> {
 
 <Note>
 
-GUI アプリのコンテキストでは `which` が信頼できない場合があるため、ハードコードされたパスを最初に確認する。`/usr/bin/which`（`which` だけではなく）を使用するのは、アプリの `PATH` に `/usr/bin` が含まれていない可能性があるためである。
+GUI アプリのコンテキストでは `which` が信頼できない場合があるため、ハードコードされたパスを最初に確認する。`/usr/bin/which`（`which` だけではなく）を使用するのは、アプリの `PATH` に `/usr/bin` が含まれていない可能性があるためである。ユーザーが Volta で Node を pin しているケースが多い場合は `$HOME/.volta/bin/pnpm` もハードコードリストに含める -- Finder 起動は Volta のシム注入を見ない。
 
 </Note>
 
@@ -351,6 +353,119 @@ app.on_menu_event(|app_handle, event| match event.id().as_ref() {
 `sidecar_for_exit` は、クロージャに移動する前に `AppState` からクローンされた `Arc<Mutex<Option<Sidecar>>>` である。`run()` クロージャはムーブキャプチャを行い、`setup()` クロージャよりも長く存続するため、これが必要となる。
 
 </Note>
+
+## sidecar でのコールドインストールブートストラップ
+
+バンドル sidecar 型のドキュメントビューアーは、`node_modules/` が埋まっていることに依存する。クリーンな clone 直後 -- またはユーザーがキャッシュディレクトリを消去した後 -- では `node_modules/astro/astro.js` が存在せず、sidecar は起動に失敗し、webview は永遠にローディングページのままになる。
+
+解決策は、sidecar 自身のエントリースクリプト内にプレビルドガードを入れることだ。エントリーポイントの欠損を検出し、先に `pnpm install` を走らせてから次に進む。無言で失敗する代わりに UX を「ビルド中」の状態に保つ。
+
+```js
+// doc/scripts/dev-stable.js
+import { existsSync } from "node:fs";
+import { spawn } from "node:child_process";
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+
+function findPnpm() {
+  const candidates = [
+    "/opt/homebrew/bin/pnpm",
+    "/usr/local/bin/pnpm",
+    `${process.env.HOME}/.volta/bin/pnpm`,
+  ];
+  for (const p of candidates) {
+    if (existsSync(p)) return p;
+  }
+  // Fallback: /usr/bin/which
+  try {
+    const { execFileSync } = require("node:child_process");
+    const p = execFileSync("/usr/bin/which", ["pnpm"]).toString().trim();
+    return p && existsSync(p) ? p : null;
+  } catch {
+    return null;
+  }
+}
+
+async function ensureNodeModules(root = ROOT) {
+  // Fast path: astro.js が既にあればスキップ。
+  if (existsSync(path.join(root, "node_modules/astro/astro.js"))) return;
+
+  const pnpm = findPnpm();
+  if (!pnpm) {
+    console.error(
+      "pnpm not found — install Node.js and pnpm before launching.",
+    );
+    process.exit(1);
+  }
+
+  await new Promise((resolve, reject) => {
+    const child = spawn(pnpm, ["install", "--prefer-offline"], {
+      cwd: root,
+      stdio: "inherit", // ログは sidecar.log に流れる
+    });
+    child.on("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`pnpm install exited with code ${code}`));
+    });
+  });
+}
+
+// Main
+try {
+  await serve(); // build() が終わるまで /___ready は 503
+  await ensureNodeModules();
+  await build();
+} catch (err) {
+  console.error("sidecar fatal:", err);
+  process.exit(1);
+}
+```
+
+間違えやすい勘所が 3 つある:
+
+1. **Finder / launchd の PATH は最小限。** Finder から起動された `.app` の内部では、`PATH` は典型的に `/usr/bin:/bin:/usr/sbin:/sbin` だけだ。ユーザーのシェル `PATH` に乗っている `pnpm` には届かない。絶対パスを先に探り、`/usr/bin/which pnpm` にフォールバックし、どちらも駄目なら明確なメッセージで終了する。[Rust 側の `find_pnpm()` 戦略](#pnpm-の検索)と同じ考え方だ。
+
+2. **インストール中もローディングページは有効のまま。** `pnpm install` が走っている間、sidecar の `/___ready` は 503 を返し続ける。Rust の準備完了ポーラーも sidecar 側の `LOADING_HTML` の自動リフレッシュも「まだビルド中」のスピナーを表示したまま -- インストール中の UX 劣化は起きない。インストールのログは `stdio: "inherit"` を通って sidecar ログに流れるので、エラー状態のローディングページが表示するファイルに残る。
+
+3. **pnpm 不在時の明確な停止。** `findPnpm()` が `null` を返したら、「pnpm not found」のメッセージを stderr に出して `process.exit(1)` する。そうすれば [`wait_for_ready` の sidecar 死亡検出器](../architecture/process-lifecycle.mdx#準備完了ループでの-sidecar-の死亡検出)が約 1 秒で `launch-error` 経由でユーザーに失敗を通知できる。無言でハングさせると UI はスピナーのまま固まる。
+
+<Tip>
+
+ファストパスの `existsSync(node_modules/astro/astro.js)` ショートサーキットは、起動ごとに `stat` を 1 回呼ぶだけのコストで保険になる。省略すると、何も変わっていないときでもフルの `pnpm install` が起動のたびに走り、ユーザーはスピナーの余分な 1〜2 秒に気付く。
+
+</Tip>
+
+### コールドパスのスモークテスト
+
+コールドインストールパスは `node_modules/` が空のときしか走らないため、テストしなければ無言で劣化する。`--cold` フラグを付けた最小の起動スクリプトで回帰の監視面を可視化する:
+
+```bash
+#!/usr/bin/env bash
+# test-launch.sh [--cold] [iterations]
+set -euo pipefail
+
+COLD=0
+ITERS=1
+for arg in "$@"; do
+  case "$arg" in
+    --cold) COLD=1 ;;
+    *) ITERS="$arg" ;;
+  esac
+done
+
+if [[ "$COLD" -eq 1 ]]; then
+  # イテレーション毎ではなく最初の 1 回前に 1 度だけ消す -- マルチラン時も
+  # コールドパスはちょうど 1 回だけ走り、残りは定常状態の再起動を測る。
+  rm -rf "./node_modules"
+fi
+
+for i in $(seq 1 "$ITERS"); do
+  open -W -a "MyApp.app"
+done
+```
+
+これで 1 回目のイテレーションで `ensureNodeModules` のブートストラップを走らせ、それ以降は健全な再起動を測る。CI（あるいは各リリース前）で回しておけば、フレッシュインストールのパスが気付かぬうちに壊れることはなくなる。
 
 ## 設定ファイル
 

--- a/src/content/docs/architecture/loading-screen.mdx
+++ b/src/content/docs/architecture/loading-screen.mdx
@@ -280,3 +280,137 @@ fn do_refresh(app_handle: &AppHandle) {
 ```
 
 This kills the old sidecar, cleans up the port, spawns a new one, waits for it to be ready, and then navigates. The timeout for refresh (15 seconds) is shorter than the initial startup timeout (120 seconds) because the server is expected to start faster on subsequent launches.
+
+## Error State and Retry
+
+The minimal "spinner + text" loading page works for the happy path, but it lies to the user when the sidecar has already died or the build has stalled. The user sees the same spinner whether the sidecar is building normally or has crashed and will never come back.
+
+The next-level pattern is a loading page that doubles as an error panel. The spinner is the happy path; a hidden error panel listens for a backend-emitted `launch-error` event and flips into an actionable state with a Retry button.
+
+### The backend contract
+
+The Rust side emits a `launch-error` event instead of navigating when [readiness polling detects sidecar death or a timeout](./process-lifecycle.mdx#detecting-sidecar-death-in-the-readiness-loop):
+
+```rust
+// Shape of the event payload
+// { reason: "timeout" | "sidecar_exited", logPath: "/path/to/sidecar.log" }
+```
+
+A matching `retry_launch` command triggers the restart so the frontend can offer a Retry button:
+
+```rust
+#[tauri::command]
+fn retry_launch(app_handle: AppHandle) {
+    // Spawn on a background thread — never block the IPC thread.
+    // do_refresh() re-emits launch-error on failure, so a retry
+    // that fails again naturally flips the UI back to the error state.
+    thread::spawn(move || {
+        do_refresh(&app_handle);
+    });
+}
+```
+
+<Warning>
+
+Never run a long restart inline on the IPC thread. Tauri's IPC runtime dispatches commands on a small thread pool; a `retry_launch` that spawns a sidecar, waits 15 s for readiness, and then returns will block other commands for that entire window. Spawn the work on a background `std::thread` and return immediately.
+
+</Warning>
+
+### The frontend panel
+
+The loading HTML grows a hidden error panel. Inline CSS and JS only — the page is bundled and has no bundler, so imports are not an option:
+
+```html
+<!-- frontend/index.html (abbreviated) -->
+<body>
+  <div id="spinner" class="spinner"></div>
+  <div id="long-hint" class="sub" hidden>Taking longer than usual…</div>
+
+  <div id="error-panel" hidden>
+    <h2>Could not start the documentation server</h2>
+    <p id="error-reason"></p>
+    <p class="log"><code id="error-log-path"></code></p>
+    <button id="retry">Retry</button>
+    <button id="copy-log">Copy log path</button>
+  </div>
+
+  <script>
+    const { event, core } = window.__TAURI__;
+
+    event.listen("launch-error", ({ payload }) => {
+      document.getElementById("spinner").hidden = true;
+      document.getElementById("long-hint").hidden = true;
+      document.getElementById("error-reason").textContent =
+        payload.reason === "sidecar_exited"
+          ? "The background server exited before becoming ready."
+          : "The server took too long to respond.";
+      document.getElementById("error-log-path").textContent = payload.logPath;
+      document.getElementById("error-panel").hidden = false;
+    });
+
+    document.getElementById("retry").addEventListener("click", () => {
+      document.getElementById("error-panel").hidden = true;
+      document.getElementById("spinner").hidden = false;
+      core.invoke("retry_launch");
+    });
+
+    document.getElementById("copy-log").addEventListener("click", () => {
+      navigator.clipboard.writeText(
+        document.getElementById("error-log-path").textContent,
+      );
+    });
+
+    // Belt-and-suspenders: if we are still on the loading page after 20s,
+    // hint that things are taking longer than usual. Distinct from an error —
+    // the spinner keeps spinning, the panel stays hidden.
+    setTimeout(() => {
+      if (document.getElementById("error-panel").hidden) {
+        document.getElementById("long-hint").hidden = false;
+      }
+    }, 20_000);
+  </script>
+</body>
+```
+
+<Note>
+
+The 20-second "taking longer than usual" hint is visually distinct from the error panel. It nudges users who are on a slow first build (large dependency install, cold cargo cache) without falsely signalling failure. The error panel only appears when the backend has actually emitted `launch-error`.
+
+</Note>
+
+### Two prerequisites for the bundled page
+
+Because `frontend/index.html` is bundled and has no bundler, `window.__TAURI__` is the only way to reach the Tauri API. Two config details must line up:
+
+1. **`withGlobalTauri: true` in `tauri.conf.json`** — in Tauri v2 the default is `false`, meaning `window.__TAURI__` does not exist. If you forget this, `event.listen` and `core.invoke` silently do nothing and the panel never wires up.
+2. **`core:default` capability** — this already covers both `event:listen` and custom command invokes for the window. No additional capability grants are needed.
+
+See [IPC → Calling IPC from a bundled loading page](../frontend/ipc-commands.mdx#calling-ipc-from-a-bundled-loading-page) for the config details.
+
+### Sequence
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Rust as Rust Main
+  participant Window as Loading Page
+  participant Sidecar
+
+  Rust->>Sidecar: spawn_sidecar()
+  Rust->>Window: loading page visible
+  Note over Window: spinner + "Starting…"
+
+  alt Sidecar dies early
+    Sidecar--xRust: exits before /___ready is 200
+    Rust->>Window: emit("launch-error", { reason: "sidecar_exited" })
+    Window-->>User: error panel + Retry button
+    User->>Window: click Retry
+    Window->>Rust: invoke("retry_launch")
+    Rust->>Sidecar: do_refresh() on background thread
+  else Healthy but slow
+    Note over Window: after 20s, "Taking longer than usual…"
+    Sidecar-->>Rust: /___ready → 200
+    Rust->>Window: navigate(server_url)
+    Window-->>User: real content
+  end
+```

--- a/src/content/docs/architecture/process-lifecycle.mdx
+++ b/src/content/docs/architecture/process-lifecycle.mdx
@@ -338,6 +338,102 @@ sequenceDiagram
   Rust->>Rust: app_handle.exit(0)
 ```
 
+## Detecting Sidecar Death in the Readiness Loop
+
+The naive readiness loop polls `/___ready` and either returns `Ready` or gives up after a timeout. That works when the sidecar is healthy, but it burns the full timeout whenever the sidecar has already died — typically because a dependency like `node_modules/` is missing on a fresh install. The user sees the loading page for the full 120 s and then the app navigates to a dead port anyway.
+
+The fix is to let `wait_for_ready` short-circuit when the child process has exited. Pass the sidecar handle in and call `Child::try_wait()` each poll tick:
+
+```rust
+pub enum ReadyResult {
+    Ready,
+    Timeout,
+    SidecarExited { code: Option<i32> },
+}
+
+pub fn wait_for_ready(
+    sidecar: &Arc<Mutex<Option<Sidecar>>>,
+    timeout: Duration,
+) -> ReadyResult {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        // Scope the lock narrowly — do NOT hold it across the curl call.
+        if let Ok(mut guard) = sidecar.lock() {
+            if let Some(s) = guard.as_mut() {
+                match s.child.try_wait() {
+                    Ok(Some(status)) => {
+                        return ReadyResult::SidecarExited {
+                            code: status.code(),
+                        };
+                    }
+                    Ok(None) => {} // still running
+                    Err(e) => log(&format!("try_wait error: {e}")),
+                }
+            }
+        }
+
+        let code = check_ready();
+        if code != "000" && code != "err" {
+            thread::sleep(Duration::from_secs(1));
+            return ReadyResult::Ready;
+        }
+        thread::sleep(Duration::from_secs(1));
+    }
+    ReadyResult::Timeout
+}
+```
+
+Three details matter:
+
+- **`try_wait()` is cheap.** It is a single `waitpid(WNOHANG)` syscall that returns `Ok(None)` while the child runs and `Ok(Some(status))` once it exits. Safe to call in a 1 Hz poll.
+- **Scope the mutex lock narrowly.** Acquire → `try_wait()` → drop the guard before running `curl`. Holding the guard across the network call would block refresh, exit, and any other path that needs the same mutex.
+- **Both call sites branch on `ReadyResult`.** `setup()`'s initial launch and `do_refresh()` both consume the enum and surface a `launch-error` event instead of navigating to a dead port. See [Loading Screen → Error state and retry](./loading-screen.mdx#error-state-and-retry) for the frontend side.
+
+<Warning>
+
+Do NOT hold the `Mutex<Option<Sidecar>>` guard across the `curl` call. A one-second curl with the lock held is enough to stall any refresh, retry, or window-close event that also needs to touch the sidecar. Scope the guard to just the `try_wait()` read.
+
+</Warning>
+
+### Emitting a launch-error event
+
+When `wait_for_ready` returns `Timeout` or `SidecarExited`, emit a Tauri event instead of navigating to a dead URL. The loading page listens for it and flips into an error state (see loading-screen.mdx).
+
+```rust
+use tauri::{AppHandle, Emitter, Manager};
+
+fn emit_launch_error(app_handle: &AppHandle, reason: &str) {
+    if let Some(w) = app_handle.get_webview_window("main") {
+        let _ = w.emit(
+            "launch-error",
+            serde_json::json!({
+                "reason": reason,
+                "logPath": sidecar_log_path().to_string_lossy(),
+            }),
+        );
+    }
+}
+
+// In setup() / do_refresh():
+match wait_for_ready(&state.sidecar, Duration::from_secs(120)) {
+    ReadyResult::Ready => {
+        let _ = w.navigate(server_url().parse().unwrap());
+    }
+    ReadyResult::Timeout => emit_launch_error(&handle, "timeout"),
+    ReadyResult::SidecarExited { .. } => {
+        emit_launch_error(&handle, "sidecar_exited");
+    }
+}
+```
+
+<Tip>
+
+`tauri::Emitter` is the v2 trait that adds `.emit()` to `AppHandle` and `WebviewWindow`. Emitting from the window (not the app handle) targets that window's frontend listeners cleanly.
+
+`serde_json` ships transitively via `tauri`, so promoting it from `dev-dependencies` to `dependencies` costs nothing in compile time and lets you build the payload with `serde_json::json!` instead of a custom struct.
+
+</Tip>
+
 ## Logging
 
 Both the app's own lifecycle events and the sidecar's output should be logged to separate files:

--- a/src/content/docs/frontend/ipc-commands.mdx
+++ b/src/content/docs/frontend/ipc-commands.mdx
@@ -342,6 +342,75 @@ pub fn draft_read(
 
 This keeps commands thin and focused on parameter handling, while the real logic lives in reusable functions that can be called from multiple commands.
 
+## Calling IPC from a Bundled Loading Page
+
+A wrapper app's bundled `frontend/index.html` (the loading page) often has no bundler — it is plain HTML served from `frontendDist` for exactly long enough to show a spinner before navigating to the real dev server. When that page needs to `listen` for backend events or `invoke` custom commands (e.g., `retry_launch` from an [error-state loading page](../architecture/loading-screen.mdx#error-state-and-retry)), it cannot `import` from the Tauri JS SDK. The only option is `window.__TAURI__`.
+
+Two config details have to line up, both easy to miss:
+
+### 1. Enable `withGlobalTauri`
+
+In Tauri v2, `app.withGlobalTauri` defaults to `false`. That means `window.__TAURI__` does not exist in the webview at all, so `window.__TAURI__.event.listen` is `TypeError: Cannot read properties of undefined`. The page fails silently — no frontend error surfaces unless you explicitly log the exception.
+
+```json
+// tauri.conf.json
+{
+  "app": {
+    "withGlobalTauri": true
+  }
+}
+```
+
+<Warning>
+
+This is a common "why are my event listeners not firing?" trap. If your bundled loading page uses `window.__TAURI__` at all and you did not explicitly set `withGlobalTauri: true`, nothing works and there is no frontend error. Add a defensive log at the top of the page so the failure is visible:
+
+```js
+if (!window.__TAURI__) {
+  console.error("window.__TAURI__ missing — set withGlobalTauri: true");
+}
+```
+
+</Warning>
+
+### 2. `core:default` already covers it
+
+For a typical loading page that listens for an event and invokes one or two custom commands, `core:default` in `capabilities/default.json` is sufficient. It grants `event:listen`, `event:unlisten`, and the invoke plumbing that custom `#[tauri::command]` functions use. Do **not** speculatively broaden the capability to things like `core:allow-emit-to-any` — they are not needed and only widen the surface the webview can reach.
+
+```json
+// capabilities/default.json — unchanged from the default
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "default",
+  "windows": ["main"],
+  "permissions": ["core:default"]
+}
+```
+
+### Using the globals
+
+With those two in place, the bundled page can listen and invoke directly:
+
+```html
+<script>
+  const { event, core } = window.__TAURI__;
+
+  // Listen for a backend event
+  const unlisten = await event.listen("launch-error", ({ payload }) => {
+    // payload is whatever Rust sent via Emitter::emit
+  });
+
+  // Invoke a custom command
+  await core.invoke("retry_launch");
+</script>
+```
+
+<Note>
+
+`window.__TAURI__.core.invoke` is the same function as the ESM `invoke` re-exported by `@tauri-apps/api/core`. The payload serialization and return-value deserialization are identical — a bundled page does not get a degraded API, just a different import style.
+
+</Note>
+
 ## Key takeaways
 
 1. **Register every command** in `generate_handler!` -- there is no compile-time check
@@ -351,3 +420,4 @@ This keeps commands thin and focused on parameter handling, while the real logic
 5. **Use `.map_err(|e| format!(...))` ** to convert all error types to `String`
 6. **Derive `Serialize` with `serde(rename)`** for frontend-friendly field names
 7. **Keep commands thin** -- delegate to internal helper functions
+8. **Bundled loading pages need `withGlobalTauri: true`** -- or `window.__TAURI__` silently does not exist

--- a/src/content/docs/recipes/doc-viewer-app.mdx
+++ b/src/content/docs/recipes/doc-viewer-app.mdx
@@ -43,14 +43,16 @@ const PNPM_CMD: &str = "dev";
 
 In production, the app needs to find the `pnpm` binary on the user's system. A GUI app does not inherit the user's shell `PATH`, so you cannot rely on just calling `pnpm`.
 
-The strategy: check hardcoded well-known paths first, then fall back to `which`.
+The strategy: check hardcoded well-known paths first (including version-manager shims), then fall back to `which`.
 
 ```rust
 fn find_pnpm() -> Option<PathBuf> {
     // Check well-known installation paths first
+    let home = std::env::var("HOME").ok()?;
     let candidates = [
-        "/opt/homebrew/bin/pnpm",
-        "/usr/local/bin/pnpm",
+        "/opt/homebrew/bin/pnpm".to_string(),  // Apple Silicon Homebrew
+        "/usr/local/bin/pnpm".to_string(),     // Intel Homebrew
+        format!("{home}/.volta/bin/pnpm"),     // Volta shim
     ];
     for p in &candidates {
         let path = PathBuf::from(p);
@@ -78,7 +80,7 @@ fn find_pnpm() -> Option<PathBuf> {
 
 <Note>
 
-Hardcoded paths are checked first because `which` can be unreliable in GUI app contexts. The `/usr/bin/which` path is used (not just `which`) because the app's `PATH` may not include `/usr/bin`.
+Hardcoded paths are checked first because `which` can be unreliable in GUI app contexts. The `/usr/bin/which` path is used (not just `which`) because the app's `PATH` may not include `/usr/bin`. Include `$HOME/.volta/bin/pnpm` in the hardcoded list when your users commonly pin Node via Volta — Finder launches do not see Volta's shim injection.
 
 </Note>
 
@@ -351,6 +353,120 @@ When the window is destroyed, kill the sidecar:
 The `sidecar_for_exit` is an `Arc<Mutex<Option<Sidecar>>>` cloned from `AppState` before moving into the closure. This is needed because the `run()` closure captures by move and outlives the `setup()` closure.
 
 </Note>
+
+## Cold-Install Bootstrap in the Sidecar
+
+A bundled-sidecar doc viewer depends on `node_modules/` being populated. On a fresh clone — or after the user wipes the cache directory — `node_modules/astro/astro.js` does not exist, the sidecar fails to start, and the webview sits on the loading page forever.
+
+The fix is a pre-build guard inside the sidecar's own entry script that detects the missing entrypoint and runs `pnpm install` before proceeding. It keeps the UX in the "still building" state rather than failing silently.
+
+```js
+// doc/scripts/dev-stable.js
+import { existsSync } from "node:fs";
+import { spawn } from "node:child_process";
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+
+function findPnpm() {
+  const candidates = [
+    "/opt/homebrew/bin/pnpm",
+    "/usr/local/bin/pnpm",
+    `${process.env.HOME}/.volta/bin/pnpm`,
+  ];
+  for (const p of candidates) {
+    if (existsSync(p)) return p;
+  }
+  // Fallback: /usr/bin/which
+  try {
+    const { execFileSync } = require("node:child_process");
+    const p = execFileSync("/usr/bin/which", ["pnpm"]).toString().trim();
+    return p && existsSync(p) ? p : null;
+  } catch {
+    return null;
+  }
+}
+
+async function ensureNodeModules(root = ROOT) {
+  // Fast path: if astro.js is already installed, skip.
+  if (existsSync(path.join(root, "node_modules/astro/astro.js"))) return;
+
+  const pnpm = findPnpm();
+  if (!pnpm) {
+    console.error(
+      "pnpm not found — install Node.js and pnpm before launching.",
+    );
+    process.exit(1);
+  }
+
+  await new Promise((resolve, reject) => {
+    const child = spawn(pnpm, ["install", "--prefer-offline"], {
+      cwd: root,
+      stdio: "inherit", // logs flow to sidecar.log
+    });
+    child.on("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`pnpm install exited with code ${code}`));
+    });
+  });
+}
+
+// Main
+try {
+  await serve(); // /___ready → 503 until build() finishes
+  await ensureNodeModules();
+  await build();
+} catch (err) {
+  console.error("sidecar fatal:", err);
+  process.exit(1);
+}
+```
+
+Three subtleties that are easy to get wrong:
+
+1. **Finder / launchd has a minimal PATH.** Inside a `.app` launched from Finder, `PATH` is typically just `/usr/bin:/bin:/usr/sbin:/sbin`. `pnpm` on the user's shell `PATH` is not reachable. Probe absolute paths first, fall back to `/usr/bin/which pnpm`, and bail out with a clear message if neither works. Mirrors the [`find_pnpm()` strategy in Rust](#finding-pnpm).
+
+2. **Loading page stays valid during install.** While `pnpm install` runs, the sidecar's `/___ready` endpoint keeps returning 503. Both the Rust readiness poller and the sidecar-side `LOADING_HTML` auto-refresh keep showing the "still building" spinner — no UX regression during the install. The install logs flow through `stdio: "inherit"` into the sidecar log, so they appear in the file that the error-state loading page would surface if something went wrong.
+
+3. **Clear fail-stop on missing pnpm.** If `findPnpm()` returns `null`, print a discoverable "pnpm not found" message to stderr and `process.exit(1)` so the [sidecar-death detector in `wait_for_ready`](../architecture/process-lifecycle.mdx#detecting-sidecar-death-in-the-readiness-loop) surfaces the failure to the user via `launch-error` within ~1 s. Hanging the sidecar with no exit would leave the UI stuck on the spinner.
+
+<Tip>
+
+The fast-path `existsSync(node_modules/astro/astro.js)` short-circuit costs a single `stat` call on every launch, which is worth the insurance. Skip it and you spawn a full `pnpm install` on every launch even when nothing needs to change — users will notice the extra second or two of spinner.
+
+</Tip>
+
+### Smoke-testing the cold path
+
+Because the cold-install path only runs when `node_modules/` is empty, it silently rots if you never test it. A minimal launch script with a `--cold` flag keeps the regression surface visible:
+
+```bash
+#!/usr/bin/env bash
+# test-launch.sh [--cold] [iterations]
+set -euo pipefail
+
+COLD=0
+ITERS=1
+for arg in "$@"; do
+  case "$arg" in
+    --cold) COLD=1 ;;
+    *) ITERS="$arg" ;;
+  esac
+done
+
+if [[ "$COLD" -eq 1 ]]; then
+  # Wipe once, before the first iteration, not per-iter — so multi-run
+  # smoke still exercises the cold path exactly once and then measures
+  # steady-state relaunches.
+  rm -rf "./node_modules"
+fi
+
+for i in $(seq 1 "$ITERS"); do
+  open -W -a "MyApp.app"
+done
+```
+
+This exercises the `ensureNodeModules` bootstrap on the first iteration and then measures healthy relaunches on subsequent ones. Run it in CI (or before each release) so the fresh-install path never breaks unnoticed.
 
 ## Config File
 


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/claude-settings/issues/44

---

## Summary

Capture Tauri-relevant findings from the `CCResDoc Launch Fix` epic (Takazudo/claude-settings#38, merged as Takazudo/claude-settings#45) into the wisdom base. Four articles gain new sections; `docs-ja/` mirrors updated in the same PR.

## Changes

### `architecture/process-lifecycle.mdx`

New **Detecting Sidecar Death in the Readiness Loop** section. Covers the `ReadyResult` enum (`Ready` / `Timeout` / `SidecarExited { code }`), `Child::try_wait()` per-tick polling, narrow `Mutex<Option<Sidecar>>` scoping so curl does not hold the guard, and an `emit_launch_error` helper emitting `{ reason, logPath }` via `tauri::Emitter`. From `claude-settings#39`.

### `architecture/loading-screen.mdx`

New **Error State and Retry** section. Bundled-HTML error panel that listens for `launch-error` and flips out of the spinner, `retry_launch` custom command running on a background `std::thread` (never blocking the IPC thread), and a 20 s "taking longer than usual" belt-and-suspenders hint that is visually distinct from the error state. Sequence diagram for both failure and slow-healthy paths. From `claude-settings#39` + `#42`.

### `frontend/ipc-commands.mdx`

New **Calling IPC from a Bundled Loading Page** section. `app.withGlobalTauri: true` is required in Tauri v2 for bundled HTML to reach `window.__TAURI__`; without it, `event.listen` and `core.invoke` silently do nothing. `core:default` already covers both event listen and custom invokes — no capability broadening needed. From `claude-settings#42`.

### `recipes/doc-viewer-app.mdx`

New **Cold-Install Bootstrap in the Sidecar** section. Detects missing `node_modules/astro/astro.js`, runs `pnpm install --prefer-offline` with `stdio: "inherit"` so output flows to the sidecar log, and bails out cleanly if `pnpm` cannot be found. Layered `findPnpm` (Homebrew paths, Volta shim, `/usr/bin/which` fallback). Plus a **Smoke-testing the cold path** sub-section showing a `--cold` flag on the launch-test script. The existing `find_pnpm()` Rust snippet at the top of the article also gains a Volta entry. From `claude-settings#40` + `#43`.

### Japanese mirrors

All four articles have matching updates under `src/content/docs-ja/`. Code blocks and Mermaid diagrams are identical to EN; prose translated. Anchor slugs in JA cross-links use the Astro-generated slug of the Japanese heading.

### `claude-settings#41` — nothing new

Sub-issue #41 (stale `LOADING_HTML` redirect) declared "nothing new" in its Tauri findings section. No wisdom change needed.

## Test Plan

- [x] `pnpm format:md` — all 8 changed files formatted, clean
- [x] `pnpm build` — 117 pages built, no errors
- [x] Cross-links resolve: EN anchors (`#detecting-sidecar-death-in-the-readiness-loop`, `#error-state-and-retry`, `#calling-ipc-from-a-bundled-loading-page`, `#cold-install-bootstrap-in-the-sidecar`, `#smoke-testing-the-cold-path`) and their JA counterparts all match generated `id=` attributes
- [x] `/gcoc-review` against `main` — no Critical/High/Medium findings
- [ ] Cloudflare Pages preview deploy (automated)