### PR TITLE
feat: add silent variant of setup:doc-skill for non-interactive runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "b4push": "bash scripts/run-b4push.sh",
     "gen:z-index": "node scripts/gen-z-index.mjs",
     "check:z-index": "node scripts/gen-z-index.mjs --check",
-    "setup:doc-skill": "bash scripts/setup-doc-skill.sh"
+    "setup:doc-skill": "bash scripts/setup-doc-skill.sh",
+    "setup:doc-skill-silent": "bash scripts/setup-doc-skill.sh --silent"
   },
   "dependencies": {
     "@takazudo/zfb": "0.1.0-next.51",

--- a/scripts/setup-doc-skill.sh
+++ b/scripts/setup-doc-skill.sh
@@ -7,6 +7,15 @@ set -euo pipefail
 # the user-scope skills directory (~/.claude/skills/).
 # ────────────────────────────────────────────────────────
 
+SILENT=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --silent|-y) SILENT="true" ;;
+    *) echo "Error: unknown argument '$1'" >&2; exit 1 ;;
+  esac
+  shift
+done
+
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
 # Read project name from package.json (used in the generated SKILL.md description/title text)
@@ -15,12 +24,16 @@ PROJECT_NAME=$(node -e "console.log(require('$ROOT_DIR/package.json').name || 'm
 # entry and CLAUDE.md, which both reference `tauri-wisdom`. See issue #78.
 DEFAULT_SKILL_NAME="tauri-wisdom"
 
-# Prompt for skill name
+# Prompt for skill name (skipped under --silent: use the pinned default non-interactively)
 echo ""
 echo "=== zudo-doc Skill Setup ==="
 echo ""
-read -rp "Skill name [$DEFAULT_SKILL_NAME]: " SKILL_NAME
-SKILL_NAME="${SKILL_NAME:-$DEFAULT_SKILL_NAME}"
+if [ -n "$SILENT" ]; then
+  SKILL_NAME="$DEFAULT_SKILL_NAME"
+else
+  read -rp "Skill name [$DEFAULT_SKILL_NAME]: " SKILL_NAME
+  SKILL_NAME="${SKILL_NAME:-$DEFAULT_SKILL_NAME}"
+fi
 
 # Validate skill name (allow only alphanumeric, hyphens, underscores)
 if [[ ! "$SKILL_NAME" =~ ^[a-zA-Z0-9_-]+$ ]]; then


### PR DESCRIPTION
## Summary
- Add a `--silent` flag (alias `-y`) to `scripts/setup-doc-skill.sh` that skips the interactive `read -rp` skill-name prompt and uses the pinned `DEFAULT_SKILL_NAME` directly.
- Add a `setup:doc-skill-silent` npm script that wraps the flag, giving automated flows a non-interactive entry point.
- Fixes the failure where the interactive prompt aborts on EOF under `set -euo pipefail` in non-tty runs.

## Changes
- `scripts/setup-doc-skill.sh`:
  - New argument-parsing loop near the top sets `SILENT` for `--silent` / `-y` (unknown args now error out).
  - The skill-name prompt is wrapped: under `--silent`, `SKILL_NAME` is set to `DEFAULT_SKILL_NAME` with no stdin read or question printed; without the flag, the original interactive prompt is unchanged.
  - `set -euo pipefail` and the rest of the script are untouched; the default skill name (`tauri-wisdom`) is unchanged.
- `package.json`: new `setup:doc-skill-silent` script (`bash scripts/setup-doc-skill.sh --silent`), placed directly after `setup:doc-skill`.

## Test Plan
- `pnpm setup:doc-skill-silent < /dev/null` completes with no prompt and bakes the `tauri-wisdom` skill symlink into `~/.claude/skills` — identical to answering the interactive prompt with the default.
- `bash scripts/setup-doc-skill.sh -y < /dev/null` behaves the same (alias).
- `bash scripts/setup-doc-skill.sh --bogus` exits non-zero with an "unknown argument" error.
- Flag-less `pnpm setup:doc-skill` still prompts interactively (behavior unchanged).
- `bash -n scripts/setup-doc-skill.sh` passes; CI green (8/8 checks).