### PR TITLE
ci: hand off build outputs via artifacts instead of cache in deploy pipeline

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -7,9 +7,10 @@
 #   4. Merges both build outputs and deploys to Cloudflare Workers
 #   5. Sends IFTTT notification with deploy status
 #
-# Inter-job data sharing uses actions/cache (not upload-artifact) to avoid
-# Actions storage accumulation. Cache keys are scoped to github.run_id so
-# each run gets a fresh, unique cache that won't be reused by other runs.
+# Inter-job data sharing uses upload-artifact/download-artifact with
+# retention-days: 1, scoped to github.run_id. We don't use actions/cache here
+# because cache saves are best-effort and can silently fail, leaving consumers
+# to hard-fail on a missing entry; artifacts don't touch the cache backend.
 #
 # Concurrency: only one production deploy runs at a time.
 # We do NOT cancel in-progress runs -- the earlier deploy should finish.
@@ -67,11 +68,13 @@ jobs:
       - name: Build site
         run: pnpm build
 
-      - name: Cache site build output
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Upload site build output
+        uses: actions/upload-artifact@v4
         with:
+          name: dist-${{ github.run_id }}
           path: dist/
-          key: dist-${{ github.run_id }}
+          retention-days: 1
+          if-no-files-found: error
 
   # ---------------------------------------------------------------------------
   # Job: HTML validate
@@ -100,12 +103,11 @@ jobs:
       - name: Install deps (no scripts)
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Restore dist cache (built by build-site)
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Download dist (built by build-site)
+        uses: actions/download-artifact@v4
         with:
+          name: dist-${{ github.run_id }}
           path: dist/
-          key: dist-${{ github.run_id }}
-          fail-on-cache-miss: true
 
       - name: Run html-validate
         run: pnpm check:html
@@ -146,11 +148,13 @@ jobs:
             --locale ja:src/content/docs-ja \
             --out-dir doc-history-out
 
-      - name: Cache doc history output
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Upload doc history output
+        uses: actions/upload-artifact@v4
         with:
+          name: doc-history-${{ github.run_id }}
           path: doc-history-out/
-          key: doc-history-${{ github.run_id }}
+          retention-days: 1
+          if-no-files-found: error
 
   # ---------------------------------------------------------------------------
   # Job 3: Deploy to Cloudflare Workers (production)
@@ -165,19 +169,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      - name: Restore site build cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Download site build output
+        uses: actions/download-artifact@v4
         with:
+          name: dist-${{ github.run_id }}
           path: dist/
-          key: dist-${{ github.run_id }}
-          fail-on-cache-miss: true
 
-      - name: Restore doc history cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Download doc history output
+        uses: actions/download-artifact@v4
         with:
+          name: doc-history-${{ github.run_id }}
           path: doc-history-out/
-          key: doc-history-${{ github.run_id }}
-          fail-on-cache-miss: true
 
       - name: Prepare deploy directory
         run: |

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -75,6 +75,9 @@ jobs:
           path: dist/
           retention-days: 1
           if-no-files-found: error
+          # github.run_id is stable across re-runs; upload-artifact@v4 errors on a
+          # duplicate artifact name unless overwrite is set, so a re-run would fail.
+          overwrite: true
 
   # ---------------------------------------------------------------------------
   # Job: HTML validate
@@ -155,6 +158,9 @@ jobs:
           path: doc-history-out/
           retention-days: 1
           if-no-files-found: error
+          # github.run_id is stable across re-runs; upload-artifact@v4 errors on a
+          # duplicate artifact name unless overwrite is set, so a re-run would fail.
+          overwrite: true
 
   # ---------------------------------------------------------------------------
   # Job 3: Deploy to Cloudflare Workers (production)

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -179,11 +179,13 @@ jobs:
       - name: Check links
         run: pnpm check:links
 
-      - name: Cache site build output
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Upload site build output
+        uses: actions/upload-artifact@v4
         with:
+          name: dist-${{ github.run_id }}
           path: dist/
-          key: dist-${{ github.run_id }}
+          retention-days: 1
+          if-no-files-found: error
 
   # ---------------------------------------------------------------------------
   # Job: HTML validate
@@ -211,12 +213,11 @@ jobs:
       - name: Install deps (no scripts)
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Restore dist cache (built by build-site)
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Download dist (built by build-site)
+        uses: actions/download-artifact@v4
         with:
+          name: dist-${{ github.run_id }}
           path: dist/
-          key: dist-${{ github.run_id }}
-          fail-on-cache-miss: true
 
       - name: Run html-validate
         run: pnpm check:html
@@ -257,11 +258,13 @@ jobs:
             --locale ja:src/content/docs-ja \
             --out-dir doc-history-out
 
-      - name: Cache doc history output
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Upload doc history output
+        uses: actions/upload-artifact@v4
         with:
+          name: doc-history-${{ github.run_id }}
           path: doc-history-out/
-          key: doc-history-${{ github.run_id }}
+          retention-days: 1
+          if-no-files-found: error
 
   # ---------------------------------------------------------------------------
   # Job 4: Deploy preview and comment on PR
@@ -276,19 +279,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      - name: Restore site build cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Download site build output
+        uses: actions/download-artifact@v4
         with:
+          name: dist-${{ github.run_id }}
           path: dist/
-          key: dist-${{ github.run_id }}
-          fail-on-cache-miss: true
 
-      - name: Restore doc history cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Download doc history output
+        uses: actions/download-artifact@v4
         with:
+          name: doc-history-${{ github.run_id }}
           path: doc-history-out/
-          key: doc-history-${{ github.run_id }}
-          fail-on-cache-miss: true
 
       - name: Prepare dist for deployment
         run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -186,6 +186,9 @@ jobs:
           path: dist/
           retention-days: 1
           if-no-files-found: error
+          # github.run_id is stable across re-runs; upload-artifact@v4 errors on a
+          # duplicate artifact name unless overwrite is set, so a re-run would fail.
+          overwrite: true
 
   # ---------------------------------------------------------------------------
   # Job: HTML validate
@@ -265,6 +268,9 @@ jobs:
           path: doc-history-out/
           retention-days: 1
           if-no-files-found: error
+          # github.run_id is stable across re-runs; upload-artifact@v4 errors on a
+          # duplicate artifact name unless overwrite is set, so a re-run would fail.
+          overwrite: true
 
   # ---------------------------------------------------------------------------
   # Job 4: Deploy preview and comment on PR


### PR DESCRIPTION
## Summary
- Both `pr-checks.yml` and `main-deploy.yml` passed build outputs between jobs in the same run via the Actions **cache** backend (`actions/cache/save` producers + `actions/cache/restore` consumers with `fail-on-cache-miss: true`). Cache saves are best-effort/non-fatal, so a rejected save left the producing job green while every consumer hard-failed on `fail-on-cache-miss` — this broke real deploys.
- Switched the intra-run hand-off to `actions/upload-artifact@v4` / `actions/download-artifact@v4`, which don't touch the cache backend. The producing job now fails loudly if the upload fails, instead of silently passing the failure to consumers.

## Changes
- **Producers** (`Build Site` → `dist/`, `Build Doc History` → `doc-history-out/`): `actions/cache/save` → `actions/upload-artifact@v4`, with `name` = the old cache key verbatim (`dist-${{ github.run_id }}` / `doc-history-${{ github.run_id }}`), same `path`, `retention-days: 1` (preserves the original "don't accumulate Actions storage" intent), and `if-no-files-found: error`.
- **Consumers** (`HTML validate`, `Preview Deploy`, production `Deploy`): `actions/cache/restore` (`fail-on-cache-miss: true`) → `actions/download-artifact@v4`, with `name` = the old cache key, same `path`; dropped `key:`/`fail-on-cache-miss:` (download-artifact already fails when the artifact is missing). Round-trip layout preserved (`dist/` → `dist/`, not `dist/dist/`).
- **Re-run safety**: added `overwrite: true` to all four producers. `github.run_id` is stable across GitHub's "Re-run all jobs", and `upload-artifact@v4` errors on a duplicate artifact name unless `overwrite` is set — without this a re-run (the usual flaky-deploy recovery) would fail at the upload step.
- Rewrote the `main-deploy.yml` top-of-file comment to document the artifact-based hand-off and why cache was abandoned.

## Test Plan
- This PR's own `pr-checks` run exercises the new `pr-checks.yml`: `Build Site`/`Build Doc History` upload, `HTML validate` and `Preview Deploy` download — all green, confirming the artifact round-trip and Cloudflare preview deploy work.
- Post-merge `Production Deploy` on `main` exercises `main-deploy.yml` (build → upload → html-validate/deploy download → Cloudflare production deploy).