### PR TITLE
build: bump zudo-doc to 1.2.0 + zfb next.69, wire host i18n/theme into package routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "setup:doc-skill-silent": "bash scripts/setup-doc-skill.sh --silent"
   },
   "dependencies": {
-    "@takazudo/zfb": "0.1.0-next.68",
-    "@takazudo/zfb-runtime": "0.1.0-next.68",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.68",
-    "@takazudo/zudo-doc": "^1.1.0",
+    "@takazudo/zfb": "0.1.0-next.69",
+    "@takazudo/zfb-runtime": "0.1.0-next.69",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.69",
+    "@takazudo/zudo-doc": "^1.2.0",
     "zod": "^4.0.0",
     "preact": "^10.29.1",
     "preact-render-to-string": "^6.6.6",
@@ -40,7 +40,7 @@
     "katex": "^0.16.38",
     "minisearch": "^7.2.0",
     "diff": "^8.0.3",
-    "@takazudo/zudo-doc-history-server": "^1.1.0"
+    "@takazudo/zudo-doc-history-server": "^1.2.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.0",
@@ -48,7 +48,7 @@
     "typescript": "^5.9.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.2.0",
-    "create-zudo-doc": "^1.1.0",
+    "create-zudo-doc": "^1.2.0",
     "html-validate": "^10.0.0",
     "pagefind": "^1.4.0",
     "tsx": "^4.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,20 +12,20 @@ importers:
         specifier: ^4.0.0
         version: 4.2.0
       '@takazudo/zfb':
-        specifier: 0.1.0-next.68
-        version: 0.1.0-next.68
+        specifier: 0.1.0-next.69
+        version: 0.1.0-next.69
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.68
-        version: 0.1.0-next.68
+        specifier: 0.1.0-next.69
+        version: 0.1.0-next.69
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.68
-        version: 0.1.0-next.68(@takazudo/zfb@0.1.0-next.68)
+        specifier: 0.1.0-next.69
+        version: 0.1.0-next.69(@takazudo/zfb@0.1.0-next.69)
       '@takazudo/zudo-doc':
-        specifier: ^1.1.0
-        version: 1.1.0(@takazudo/zfb-runtime@0.1.0-next.68(@takazudo/zfb@0.1.0-next.68))(@takazudo/zfb@0.1.0-next.68)(@takazudo/zudo-doc-history-server@1.1.0)(diff@8.0.4)(katex@0.16.47)(preact@10.29.2)(shiki@4.2.0)(zod@4.4.3)
+        specifier: ^1.2.0
+        version: 1.2.0(@takazudo/zfb-runtime@0.1.0-next.69(@takazudo/zfb@0.1.0-next.69))(@takazudo/zfb@0.1.0-next.69)(@takazudo/zudo-doc-history-server@1.2.0)(diff@8.0.4)(katex@0.16.47)(preact@10.29.2)(shiki@4.2.0)(zod@4.4.3)
       '@takazudo/zudo-doc-history-server':
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^1.2.0
+        version: 1.2.0
       clsx:
         specifier: ^2.1.0
         version: 2.1.1
@@ -73,8 +73,8 @@ importers:
         specifier: ^19.2.0
         version: 19.2.17
       create-zudo-doc:
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^1.2.0
+        version: 1.2.0
       html-validate:
         specifier: ^10.0.0
         version: 10.17.0
@@ -960,48 +960,48 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.68':
-    resolution: {integrity: sha512-4ks2ZyJ+nPgAW7sBOTneZENoWWfYmmw2y996Acjy7E0C1t06/WdA1pQdmQRzyOICzC8JWAgCPSuFzEBL/QG8Zw==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.69':
+    resolution: {integrity: sha512-uqxCtDXTawmlT22cP1uVvosZ0dsEqQ1/HgR/j+iN5YbLgO6PP+wiWh/UA9yYdx9wqpw37ge8BSvGiv/TKk/uNg==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.68':
-    resolution: {integrity: sha512-LFxVjKag8sE6oPOvUudng2Qr6Jkj0yHf0y0TfzPfaK8mN02NJLf0J5UycBz3jOOEwRJlr+/1yTznW8cFlzxQTA==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.69':
+    resolution: {integrity: sha512-3yI+nZdD5UCDw6iD9LCX0rMcJ/DJfiZcNLHWMuJnBz7kgOsK6lm4TmQtLOjSkBB9+nik6204/90/h/3IxSG/Yg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.68':
-    resolution: {integrity: sha512-XhAwJBZDoiCgJticab7s2RjXrHo4B6AKGlWfJqGznvQgLc8PckD+glBhGpGoEj0j8fde7dSxdwA78fyVDeiM+g==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.69':
+    resolution: {integrity: sha512-9BNc4jgVw/lONunJZi8EVHF5JHK+uJOMV2t4UITJAtdjTZyHUlaPBOb55SU9yMLdqj9mKpCV0oaP2HTEPl1/Jw==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.68':
-    resolution: {integrity: sha512-rzkIFBsh9iVQiqb0NKWjzzvo5gLVbC8Qj8Jo29qRhU9R8dHY+BXLDS4JMP45RFSOFFsGV3EJlVXhjjYXFMys1Q==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.69':
+    resolution: {integrity: sha512-9/bjocDbqnIMVWrUu7z4ZmH8h4ZYZxjcnpDn9xRy08AZvy+L6IBavq3xRPkS28rHIhxM65hbX7y+Fz7tJ3noZg==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.68':
-    resolution: {integrity: sha512-OdzbQIsthI0hMIWL3y0Py0Ps6JCgAXaZ0oQjNMYWWzX/DW+1LINiVr97C3OVlmjfIvnKL90WvDJ6fP4QEd5BwQ==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.69':
+    resolution: {integrity: sha512-rC79sP13lCkHlF+8iyDWuBoOk+ESv2m70RYcWU75zu8w2gTqqlpSc56wvO+kp3t0zVMjqdNnLq8tWtvPeq2mcQ==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.68':
-    resolution: {integrity: sha512-y5gqmQF2/W6bmWt/XDid+vjdzTaEr6GGx0Der/XJUKTnP8kzyKMF50N1Ek+A1vtT+8fMAEwpUvAVSIaZyO+ucQ==}
+  '@takazudo/zfb-runtime@0.1.0-next.69':
+    resolution: {integrity: sha512-SbGiCvjba5EKqa7UaVzKk8PUN/fNYnjgOENNzmyv8CCw7/QeOYL5dHbONFMVxOks2h5lkxuutF5od8ADC1UCwg==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.68
+      '@takazudo/zfb': 0.1.0-next.69
       react: ^19.2.3
     peerDependenciesMeta:
       react:
         optional: true
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.68':
-    resolution: {integrity: sha512-sJ1dTGqxJ3EZB1WHuTyVm7l4+HYAVF9oQ66n5QnBiMFPUjTsUFzLoCoNYlsAaDgIWmFd4I+7UhF883EuumRSEQ==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.69':
+    resolution: {integrity: sha512-E7tQKiw8NqpfYw+yceNw3uEmIWUwE+m38AdsLCS10BK/fuNksNq/AC6aAoBiGUq887JaaR8ngef4B0ejFlk5Kg==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.68':
-    resolution: {integrity: sha512-HIXioj79yfmxB8in8h9sDp53vCaVkQZKf3dHegURo1+cj3OhOiIXOQ8oh2pWFYK6fF8mkZ7FBnBRC0FGZxbxDg==}
+  '@takazudo/zfb@0.1.0-next.69':
+    resolution: {integrity: sha512-mSGeGfbaU5vt764LEr8j70Bvl6DFQDuknd61Q5l1WgaKOyKrx7yZMup/9pz6aYPGR3f1gFUH+sGJHIA9S4TJMA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
     peerDependencies:
@@ -1010,18 +1010,18 @@ packages:
       react:
         optional: true
 
-  '@takazudo/zudo-doc-history-server@1.1.0':
-    resolution: {integrity: sha512-PaH3MMwVAoUING0M/bRi+1eex4ni4OOvFuKtgaVPJXZRbCwOQcGumlrxcevcQd2nZv2dEa01yoO1AX89tYuGOQ==}
+  '@takazudo/zudo-doc-history-server@1.2.0':
+    resolution: {integrity: sha512-vnAUJSf73cj3sO/VjT213Bhhl3MyZGEqmuN/WY0/Fguo1vulujywLsIPe4jApsD/9iYtFyrDbSX96RlQtvpy+g==}
     hasBin: true
 
-  '@takazudo/zudo-doc@1.1.0':
-    resolution: {integrity: sha512-jK9xbOSkp9yl43fdsWtay6ahHJs2bpfFx8Y3abcXP5JI49u6NDZwKhMT1JWCYR3uPCbeexYN+drHJM4li1+o7g==}
+  '@takazudo/zudo-doc@1.2.0':
+    resolution: {integrity: sha512-v0cCmmTBP8SBLiQBAKHy7Cn5sz9V0jNrNkFVhmW1AJVIwrvYaSYcgtwXF3BL+ChH5hm18uHWPIxssgcsOp0e5Q==}
     hasBin: true
     peerDependencies:
       '@takazudo/zdtp': ^0.3.3
-      '@takazudo/zfb': ^0.1.0-next.67
-      '@takazudo/zfb-runtime': ^0.1.0-next.67
-      '@takazudo/zudo-doc-history-server': ^1.0.2
+      '@takazudo/zfb': ^0.1.0-next.69
+      '@takazudo/zfb-runtime': ^0.1.0-next.69
+      '@takazudo/zudo-doc-history-server': ^1.1.0
       diff: ^8.0.0
       katex: ^0.16.0
       preact: ^10.29.1
@@ -1231,8 +1231,8 @@ packages:
   cose-base@2.2.0:
     resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
 
-  create-zudo-doc@1.1.0:
-    resolution: {integrity: sha512-UQoSaqhibeOSrYTp1NJHfCERdfJpI0uxbl6ZexsbZ8O8BB4UCk4k3iBBThF46tRCh8epVuVJnSTIQT2jkZ1kFw==}
+  create-zudo-doc@1.2.0:
+    resolution: {integrity: sha512-HkHkTlz+EUoMrk/cny4ersYvV9R7QDBRsSAZLQV+/IHMv/wQgadlorxgFXavzl/9lfjKNZedqS0wlVRtkSBrDg==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -2732,42 +2732,42 @@ snapshots:
       tailwindcss: 4.3.1
       vite: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.68': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.69': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.68':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.69':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.68':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.69':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.68':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.69':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.68':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.69':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.68(@takazudo/zfb@0.1.0-next.68)':
+  '@takazudo/zfb-runtime@0.1.0-next.69(@takazudo/zfb@0.1.0-next.69)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.68
+      '@takazudo/zfb': 0.1.0-next.69
       hono: 4.12.25
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.68':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.69':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.68':
+  '@takazudo/zfb@0.1.0-next.69':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.68
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.68
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.68
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.68
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.68
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.69
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.69
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.69
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.69
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.69
 
-  '@takazudo/zudo-doc-history-server@1.1.0': {}
+  '@takazudo/zudo-doc-history-server@1.2.0': {}
 
-  '@takazudo/zudo-doc@1.1.0(@takazudo/zfb-runtime@0.1.0-next.68(@takazudo/zfb@0.1.0-next.68))(@takazudo/zfb@0.1.0-next.68)(@takazudo/zudo-doc-history-server@1.1.0)(diff@8.0.4)(katex@0.16.47)(preact@10.29.2)(shiki@4.2.0)(zod@4.4.3)':
+  '@takazudo/zudo-doc@1.2.0(@takazudo/zfb-runtime@0.1.0-next.69(@takazudo/zfb@0.1.0-next.69))(@takazudo/zfb@0.1.0-next.69)(@takazudo/zudo-doc-history-server@1.2.0)(diff@8.0.4)(katex@0.16.47)(preact@10.29.2)(shiki@4.2.0)(zod@4.4.3)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.68
-      '@takazudo/zfb-runtime': 0.1.0-next.68(@takazudo/zfb@0.1.0-next.68)
+      '@takazudo/zfb': 0.1.0-next.69
+      '@takazudo/zfb-runtime': 0.1.0-next.69(@takazudo/zfb@0.1.0-next.69)
       fs-extra: 11.3.5
       gray-matter: 4.0.3
       minimist: 1.2.8
@@ -2775,7 +2775,7 @@ snapshots:
       preact: 10.29.2
       zod: 4.4.3
     optionalDependencies:
-      '@takazudo/zudo-doc-history-server': 1.1.0
+      '@takazudo/zudo-doc-history-server': 1.2.0
       diff: 8.0.4
       katex: 0.16.47
       shiki: 4.2.0
@@ -2989,7 +2989,7 @@ snapshots:
     dependencies:
       layout-base: 2.0.1
 
-  create-zudo-doc@1.1.0:
+  create-zudo-doc@1.2.0:
     dependencies:
       '@clack/prompts': 0.9.1
       fs-extra: 11.3.5

--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -55,7 +55,7 @@ export function detectLocaleFromPath(path: string): Locale {
 }
 
 /** UI string translations */
-const translations: Record<string, Record<string, string>> = {
+export const translations: Record<string, Record<string, string>> = {
   en: {
     "nav.gettingStarted": "Getting Started",
     "nav.learn": "Learn",

--- a/zfb.config.ts
+++ b/zfb.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from "zfb/config";
 import { zudoDocPreset } from "@takazudo/zudo-doc/preset";
 import { settings } from "./src/config/settings";
 import { buildDocsSchema } from "./src/config/docs-schema";
+import { translations } from "./src/config/i18n";
+import { colorSchemes } from "./src/config/color-schemes";
 
 // The seven canonical directives registered in pages/_mdx-components.ts.
 // "details" routes to DetailsWrapper — a collapsible, NOT an admonition.
@@ -30,5 +32,5 @@ export default defineConfig({
 
   // ── Preset-owned fields (content collections, plugins, markdown,
   //    codeHighlight, resolveMarkdownLinks, trailingSlash, package-owned routes) ──
-  ...zudoDocPreset({ settings, buildDocsSchema, directiveVocabulary }),
+  ...zudoDocPreset({ settings, buildDocsSchema, directiveVocabulary, translations, colorSchemes }),
 });


### PR DESCRIPTION
## Summary

Bumps this repo to **zudo-doc 1.2.0** and the **zfb stack next.69**, and applies the 1.2.0 host wiring so package-owned routes (notably `/404`) render real translations + the real color scheme instead of the bare preset shell.

### Version bumps (pin-parity preserved)
- `@takazudo/zudo-doc` + `@takazudo/zudo-doc-history-server` `^1.1.0` → `^1.2.0`
- `create-zudo-doc` `^1.1.0` → `^1.2.0`
- `@takazudo/zfb` / `zfb-runtime` / `zfb-adapter-cloudflare` `next.68` → `next.69`
- `wrangler` stays `4.85.0` (the version zfb next.69 expects — wrangler-pin check green)

### Host wiring (the key 1.2.0 step)
- `src/config/i18n.ts`: export the `translations` table (was a private `const`).
- `zfb.config.ts`: import `translations` + `colorSchemes` and thread both into the existing `zudoDocPreset({...})` call. In 1.2.0 the preset rides them into the route-context virtual module when `packageOwnedRoutes` is on.
- Host docs catch-all routes + `packageOwnedRoutes:true` are **unchanged** — user docs routes still shadow the package docs route (real i18n/theme/islands); `404`/`sitemap`/`robots` stay package-owned and now render correctly.

## Verification (in `dist/`)
- `/404`: real translated strings ("GitHub repository", "Search", "Type to search...") + `--zd-bg: light-dark(#e2ddda, #181818)` (not the `#000000` grey fallback).
- Raw-key sweep `grep -rE 'search\.placeholder|nav\.next|header\.github' dist/` → **zero**.
- EN docs: real i18n + theme + `ImageEnlarge`/`MermaidEnlarge` islands.
- JA (`docs-ja`): real JA i18n (目次 / 検索したい単語を入力 / GitHub リポジトリ) + theme + islands (62 JA pages).
- `pnpm b4push` → **8/8 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)