### PR TITLE
chore: bump zudo-doc family to 4.4.13 and add category-metadata lint

### DIFF
--- a/.template-drift-allowlist
+++ b/.template-drift-allowlist
@@ -11,8 +11,15 @@
 # 4.x create-zudo-doc templates/base ships only pages/index.tsx,
 # pages/docs/[[...slug]].tsx, scripts/setup-doc-skill.sh, src/styles/global.css,
 # tsconfig.json (+ the i18n feature's pages/[locale]/docs/[[...slug]].tsx). Of
-# those, tsconfig.json and pages/index.tsx are byte-identical to the template
-# (NOT listed); the four below diverge intentionally.
+# those, only tsconfig.json is byte-identical to the template (NOT listed); the
+# five below diverge intentionally.
+#
+# Re-validated against create-zudo-doc 4.4.13 (up from 4.2.1): the base file set
+# and the feature directory set (claudeSkills, i18n, tauri, tauriDev) are both
+# unchanged, every entry below still genuinely diverges for the reason stated,
+# and tsconfig.json is still byte-identical. The only template that changed
+# content between 4.2.1 and 4.4.13 is scripts/setup-doc-skill.sh — see its
+# section below.
 
 # ── Host customization: brand + tight-token global.css ────────────────────
 # global.css carries this site's font overrides (Noto Sans JP body + Futura
@@ -33,6 +40,16 @@ pages/[locale]/docs/[[...slug]].tsx
 # scripts/setup-doc-skill.sh is customized with this site's skill name
 # (tauri-wisdom) and Claude + Codex targets, so it diverges from the template
 # default. The skill it emits is gitignored.
+#
+# NOTE (4.4.13): this is the one template whose content changed since 4.2.1.
+# Upstream added nested-project / worktree correctness — PROJECT_PREFIX,
+# REPO_DOCS_DIR, MAIN_PROJECT_DIR and package.json-driven format-script
+# detection (zudolab/zudo-doc#2918) — so the emitted SKILL.md points at the main
+# worktree's project dir instead of the current worktree. Our fork predates all
+# of that and still hard-codes `$REPO_ROOT/src/content/docs` and `pnpm
+# format:md`. Deliberately NOT adopted here: porting it means re-forking a
+# heavily customized file, which is out of scope for the 4.4.13 bump. Tracked
+# separately so it is not lost.
 scripts/setup-doc-skill.sh
 
 # ── Wide home page override (css-wisdom PR #182 parity) ──

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "preview": "zfb preview",
     "check": "zfb check",
     "check:html": "html-validate \"dist/**/*.html\"",
+    "check:category-meta": "node scripts/check-category-meta.mjs",
     "check:pin-parity": "node scripts/check-pin-parity.mjs",
     "check:wrangler-pin": "node scripts/check-wrangler-pin.mjs",
     "check:links": "node scripts/check-links.js --strict-broken --allowlist=.check-links-allowlist",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@takazudo/zfb-runtime": "0.1.0-next.89",
     "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.89",
     "@takazudo/zfb-md-wasm": "0.1.0-next.89",
-    "@takazudo/zudo-doc": "^4.2.1",
+    "@takazudo/zudo-doc": "^4.4.13",
     "zod": "^4.3.6",
     "preact": "^10.29.1",
     "preact-render-to-string": "^6.6.6",
@@ -49,7 +49,7 @@
     "diff": "^8.0.3",
     "@takazudo/zdtp": "0.4.9",
     "minisearch": "^7.2.0",
-    "@takazudo/zudo-doc-history-server": "^4.2.1"
+    "@takazudo/zudo-doc-history-server": "^4.4.13"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.0",
@@ -57,7 +57,7 @@
     "typescript": "^5.9.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.2.0",
-    "create-zudo-doc": "^4.2.1",
+    "create-zudo-doc": "^4.4.13",
     "html-validate": "^10.0.0",
     "pagefind": "^1.4.0",
     "npm-run-all2": "^7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,11 +27,11 @@ importers:
         specifier: 0.1.0-next.89
         version: 0.1.0-next.89(@takazudo/zfb@0.1.0-next.89)
       '@takazudo/zudo-doc':
-        specifier: ^4.2.1
-        version: 4.2.1(@takazudo/zdtp@0.4.9(preact@10.29.2))(@takazudo/zfb-md-wasm@0.1.0-next.89)(@takazudo/zfb-runtime@0.1.0-next.89(@takazudo/zfb@0.1.0-next.89))(@takazudo/zfb@0.1.0-next.89)(@takazudo/zudo-doc-history-server@4.2.1)(@types/node@22.19.21)(diff@8.0.4)(katex@0.16.47)(preact@10.29.2)(shiki@4.2.0)(zod@4.4.3)
+        specifier: ^4.4.13
+        version: 4.4.13(@takazudo/zdtp@0.4.9(preact@10.29.2))(@takazudo/zfb-md-wasm@0.1.0-next.89)(@takazudo/zfb-runtime@0.1.0-next.89(@takazudo/zfb@0.1.0-next.89))(@takazudo/zfb@0.1.0-next.89)(@takazudo/zudo-doc-history-server@4.4.13)(@types/node@22.19.21)(diff@8.0.4)(katex@0.16.47)(preact@10.29.2)(zod@4.4.3)
       '@takazudo/zudo-doc-history-server':
-        specifier: ^4.2.1
-        version: 4.2.1
+        specifier: ^4.4.13
+        version: 4.4.13
       diff:
         specifier: ^8.0.3
         version: 8.0.4
@@ -76,8 +76,8 @@ importers:
         specifier: ^19.2.0
         version: 19.2.17
       create-zudo-doc:
-        specifier: ^4.2.1
-        version: 4.2.1
+        specifier: ^4.4.13
+        version: 4.4.13
       html-validate:
         specifier: ^10.0.0
         version: 10.17.0
@@ -1161,23 +1161,22 @@ packages:
       react:
         optional: true
 
-  '@takazudo/zudo-doc-history-server@4.2.1':
-    resolution: {integrity: sha512-qpG0h2JUglWdfLbY7FqHzRhsUwV/QT3Ztw/FnItyZ4Zoywu1Flchv9hS7MaQkx27t7PjLmf8U1fcRe0ZkK42iw==}
+  '@takazudo/zudo-doc-history-server@4.4.13':
+    resolution: {integrity: sha512-+gN80sd69kJkdMD8SZzXYg6RN7F4unO27xmRUicyCUjdTtD0ENYPo3HaEYgu0sgEJ9qwtejc6yF1Tju5spD4jw==}
     hasBin: true
 
-  '@takazudo/zudo-doc@4.2.1':
-    resolution: {integrity: sha512-PocAovdxqoBtP7eUO21zihvrFxduK11uh3aWIOzUvZuAMGqyfsoZsv/tMYiBHcwexCWNzvkmaZhsCOX3E4nbNw==}
+  '@takazudo/zudo-doc@4.4.13':
+    resolution: {integrity: sha512-76k2H0xsU3ifA7YPQPJIS7yJGEgSkBNN7p+w518DzxLHqOI2Y5ZLyJueF5kyHajqA+mlY8zd/Wlp6EJ3pHzJGQ==}
     hasBin: true
     peerDependencies:
       '@takazudo/zdtp': ^0.4.9
-      '@takazudo/zfb': ^0.1.0-next.89
-      '@takazudo/zfb-md-wasm': ^0.1.0-next.89
-      '@takazudo/zfb-runtime': ^0.1.0-next.89
-      '@takazudo/zudo-doc-history-server': ^4.0.0
+      '@takazudo/zfb': ^0.1.0-next.99
+      '@takazudo/zfb-md-wasm': ^0.1.0-next.99
+      '@takazudo/zfb-runtime': ^0.1.0-next.99
+      '@takazudo/zudo-doc-history-server': ^4.4.11
       diff: ^8.0.0
       katex: ^0.16.0
       preact: ^10.29.1
-      shiki: ^4.0.2
       zod: ^4.3.6
     peerDependenciesMeta:
       '@takazudo/zdtp':
@@ -1189,8 +1188,6 @@ packages:
       diff:
         optional: true
       katex:
-        optional: true
-      shiki:
         optional: true
 
   '@tybys/wasm-util@0.10.2':
@@ -1398,8 +1395,8 @@ packages:
   cose-base@2.2.0:
     resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
 
-  create-zudo-doc@4.2.1:
-    resolution: {integrity: sha512-AimkdpuBuahsmqzzDgyq4LjZsOIxS5XldFKS+8wJ5o9lYf180GDFSJbLN2xNYH2CKTVpty9nwNMcEThwOXfQuQ==}
+  create-zudo-doc@4.4.13:
+    resolution: {integrity: sha512-66XqqePHfdI4X5sgAtIuDSOdYWYTjcVV9be2SbwkDG9iFLPYzab7vqU2b1c7nvKIBtaRmxVBqXa7nhzoMfiHpw==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -3162,9 +3159,9 @@ snapshots:
       '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.89
       '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.89
 
-  '@takazudo/zudo-doc-history-server@4.2.1': {}
+  '@takazudo/zudo-doc-history-server@4.4.13': {}
 
-  '@takazudo/zudo-doc@4.2.1(@takazudo/zdtp@0.4.9(preact@10.29.2))(@takazudo/zfb-md-wasm@0.1.0-next.89)(@takazudo/zfb-runtime@0.1.0-next.89(@takazudo/zfb@0.1.0-next.89))(@takazudo/zfb@0.1.0-next.89)(@takazudo/zudo-doc-history-server@4.2.1)(@types/node@22.19.21)(diff@8.0.4)(katex@0.16.47)(preact@10.29.2)(shiki@4.2.0)(zod@4.4.3)':
+  '@takazudo/zudo-doc@4.4.13(@takazudo/zdtp@0.4.9(preact@10.29.2))(@takazudo/zfb-md-wasm@0.1.0-next.89)(@takazudo/zfb-runtime@0.1.0-next.89(@takazudo/zfb@0.1.0-next.89))(@takazudo/zfb@0.1.0-next.89)(@takazudo/zudo-doc-history-server@4.4.13)(@types/node@22.19.21)(diff@8.0.4)(katex@0.16.47)(preact@10.29.2)(zod@4.4.3)':
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@22.19.21)
       '@takazudo/zfb': 0.1.0-next.89
@@ -3181,10 +3178,9 @@ snapshots:
     optionalDependencies:
       '@takazudo/zdtp': 0.4.9(preact@10.29.2)
       '@takazudo/zfb-md-wasm': 0.1.0-next.89
-      '@takazudo/zudo-doc-history-server': 4.2.1
+      '@takazudo/zudo-doc-history-server': 4.4.13
       diff: 8.0.4
       katex: 0.16.47
-      shiki: 4.2.0
     transitivePeerDependencies:
       - '@types/node'
 
@@ -3407,7 +3403,7 @@ snapshots:
     dependencies:
       layout-base: 2.0.1
 
-  create-zudo-doc@4.2.1:
+  create-zudo-doc@4.4.13:
     dependencies:
       '@clack/prompts': 0.9.1
       fs-extra: 11.3.5

--- a/scripts/check-category-meta.mjs
+++ b/scripts/check-category-meta.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+
+/**
+ * check-category-meta.mjs — guard against silently-dropped category metadata.
+ *
+ * CANONICAL COPY: wisdom-tweaker/shared/scripts/. Distributed verbatim to every
+ * *-wisdom repo as scripts/check-category-meta.mjs. Edit it here, then re-sync.
+ *
+ * Why this exists (Takazudo/zudo-css-wisdom#183):
+ *
+ *   zudo-doc's `loadCategoryMeta` reads `_category_.json` with `node:fs`. Under
+ *   zfb — zudo-doc's own host — the SSG bundle is built `--platform=neutral
+ *   --external:node:*`, and zfb's embedded-V8 host resolves `node:fs` to a
+ *   throwing proxy. `scanDir` swallows the throw in a bare `catch { return; }`
+ *   and caches the resulting EMPTY map for the process lifetime.
+ *
+ *   Every `label`, `position`, `description` and `noPage` in every sidecar is
+ *   therefore discarded — with no error, no warning, and a green build. In
+ *   css-wisdom that silently published 36 category pages marked `noPage: true`,
+ *   ~14% of the sitemap, and nobody noticed for months.
+ *
+ * Neither `zfb check`, `html-validate`, nor `check-links --strict-broken` can
+ * see this: nothing is a broken link, the pages render fine — they simply
+ * should not exist. Hence a dedicated source-level check.
+ *
+ * Checks:
+ *   1. FAIL on any `_category_.json` under src/. Upstream retired the sidecar in
+ *      favour of index.mdx frontmatter; any remaining file is dead weight that
+ *      reads as configuration but is silently ignored.
+ *   2. FAIL when a `headerNav` entry targets a page with
+ *      `category_no_page: true`. Suppressing a category that the header links to
+ *      turns that link into a site-wide 404, and zfb's `--strict-broken` does
+ *      NOT catch it (measured on the zfb docs site).
+ *
+ * Unresolvable headerNav paths are reported as warnings, not failures — the
+ * path→file resolution below is a heuristic and must never fail a build on its
+ * own uncertainty.
+ *
+ * Usage: node scripts/check-category-meta.mjs
+ * Exit:  0 = OK (warnings allowed), 1 = violations found
+ */
+
+import { readFile, readdir, access } from "node:fs/promises";
+import { join, relative } from "node:path";
+
+const ROOT = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
+const SRC = join(ROOT, "src");
+const CONFIG = join(ROOT, "zfb.config.ts");
+
+const SKIP_DIRS = new Set(["node_modules", ".git", "dist", ".astro", ".zfb", ".zfb-build"]);
+
+async function exists(p) {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function walk(dir, out = []) {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    if (e.isDirectory()) {
+      if (SKIP_DIRS.has(e.name)) continue;
+      await walk(join(dir, e.name), out);
+    } else {
+      out.push(join(dir, e.name));
+    }
+  }
+  return out;
+}
+
+/** Extract the leading `---` frontmatter block, or "" when absent. */
+function frontmatter(source) {
+  const m = source.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  return m ? m[1] : "";
+}
+
+function hasNoPage(fm) {
+  return /^\s*category_no_page\s*:\s*true\s*$/m.test(fm);
+}
+
+/**
+ * Pull `path:` values out of the `headerNav: [ ... ]` array in zfb.config.ts.
+ * Regex rather than a TS parse: the config is a plain literal in every wisdom
+ * repo, and this script must stay dependency-free.
+ */
+function parseHeaderNav(source) {
+  const start = source.indexOf("headerNav:");
+  if (start === -1) return [];
+  const open = source.indexOf("[", start);
+  if (open === -1) return [];
+  let depth = 0;
+  let end = -1;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === "[") depth++;
+    else if (source[i] === "]") {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  if (end === -1) return [];
+  const block = source.slice(open, end);
+  return [...block.matchAll(/path\s*:\s*["'`]([^"'`]+)["'`]/g)].map((m) => m[1]);
+}
+
+function parseDocsDir(source) {
+  const m = source.match(/docsDir\s*:\s*["']([^"']+)["']/);
+  return m ? m[1] : "src/content/docs";
+}
+
+function parseBase(source) {
+  const m = source.match(/\bbase\s*:\s*["']([^"']*)["']/);
+  return m ? m[1] : "/";
+}
+
+const failures = [];
+const warnings = [];
+
+// ── Check 1: no _category_.json sidecars ──────────────────────────────────
+const srcFiles = await walk(SRC);
+const sidecars = srcFiles.filter((f) => f.endsWith("/_category_.json"));
+
+for (const f of sidecars) {
+  failures.push(
+    `[SIDECAR] ${relative(ROOT, f)} — _category_.json is silently ignored by ` +
+      `zudo-doc under zfb. Move label/position/description/noPage into the ` +
+      `directory's index.mdx frontmatter (sidebar_label / sidebar_position / ` +
+      `description / category_no_page) and delete this file.`,
+  );
+}
+
+// ── Check 2: headerNav must not target a suppressed category ──────────────
+if (await exists(CONFIG)) {
+  const configSource = await readFile(CONFIG, "utf-8");
+  const navPaths = parseHeaderNav(configSource);
+  const docsDir = parseDocsDir(configSource);
+  const base = parseBase(configSource);
+
+  for (const navPath of navPaths) {
+    // Strip the configured base prefix, then the leading route segment
+    // (`/docs`), leaving the docsDir-relative slug.
+    let slug = navPath;
+    if (base && base !== "/" && slug.startsWith(base)) slug = slug.slice(base.length);
+    slug = slug.replace(/^\/+/, "").replace(/\/+$/, "");
+    if (slug === "docs") slug = "";
+    else if (slug.startsWith("docs/")) slug = slug.slice("docs/".length);
+
+    const candidates = slug
+      ? [join(ROOT, docsDir, slug, "index.mdx"), join(ROOT, docsDir, `${slug}.mdx`)]
+      : [join(ROOT, docsDir, "index.mdx")];
+
+    let resolved = null;
+    for (const c of candidates) {
+      if (await exists(c)) {
+        resolved = c;
+        break;
+      }
+    }
+
+    if (!resolved) {
+      warnings.push(
+        `[UNRESOLVED] headerNav "${navPath}" — could not resolve to a source ` +
+          `file under ${docsDir}/. Verify the link manually; this check could ` +
+          `not.`,
+      );
+      continue;
+    }
+
+    const fm = frontmatter(await readFile(resolved, "utf-8"));
+    if (hasNoPage(fm)) {
+      failures.push(
+        `[NAV-404] headerNav "${navPath}" targets ${relative(ROOT, resolved)}, ` +
+          `which sets category_no_page: true. That page is never emitted, so ` +
+          `the header link 404s site-wide. Remove the nav entry or drop ` +
+          `category_no_page.`,
+      );
+    }
+  }
+} else {
+  warnings.push(`[NO-CONFIG] ${relative(ROOT, CONFIG)} not found — headerNav check skipped.`);
+}
+
+// ── Report ────────────────────────────────────────────────────────────────
+for (const w of warnings) console.warn(`  ⚠️  ${w}`);
+
+if (failures.length === 0) {
+  const scanned = sidecars.length === 0 ? "no sidecars" : `${sidecars.length} sidecars`;
+  console.log(`OK — category metadata check passed (${scanned}).`);
+  process.exit(0);
+}
+
+console.error("");
+console.error(`FAILED — ${failures.length} category metadata problem(s):`);
+for (const f of failures) console.error(`   - ${f}`);
+process.exit(1);

--- a/scripts/run-b4push.sh
+++ b/scripts/run-b4push.sh
@@ -5,21 +5,22 @@ set -euo pipefail
 #
 # Step order (cheap → expensive):
 #   1. Format check (mdx)
-#   2. Template drift check (needs node_modules — create-zudo-doc devDep)
-#   3. Pin parity check (pure-Node, reads package.json only)
-#   4. Wrangler pin check (needs node_modules — reads the zfb platform binary)
-#   5. Type checking (zfb check)
-#   6. Build (zfb build)
-#   7. HTML validation (html-validate dist/**/*.html)
-#   8. Link check (check-links)
+#   2. Category metadata check (pure-Node, reads src/ + zfb.config.ts)
+#   3. Template drift check (needs node_modules — create-zudo-doc devDep)
+#   4. Pin parity check (pure-Node, reads package.json only)
+#   5. Wrangler pin check (needs node_modules — reads the zfb platform binary)
+#   6. Type checking (zfb check)
+#   7. Build (zfb build)
+#   8. HTML validation (html-validate dist/**/*.html)
+#   9. Link check (check-links)
 #
 # Env overrides for non-interactive use:
-#   B4PUSH_SKIP_HTML_VALIDATE=1  — skip HTML validation (step 7)
-#   B4PUSH_SKIP_LINK_CHECK=1     — skip link check (step 8)
+#   B4PUSH_SKIP_HTML_VALIDATE=1  — skip HTML validation (step 8)
+#   B4PUSH_SKIP_LINK_CHECK=1     — skip link check (step 9)
 
 START_TIME=$(date +%s)
 FAILURES=()
-TOTAL_STEPS=8
+TOTAL_STEPS=9
 CURRENT_STEP=0
 
 step() {
@@ -44,7 +45,19 @@ else
   fail "Format check"
 fi
 
-# ── Step 2: Template drift check ──────────────────────
+# ── Step 2: Category metadata check ───────────────────
+# Pure-Node: reads src/ + zfb.config.ts only, no install needed.
+# Catches category metadata that zudo-doc silently discards under zfb —
+# a stray _category_.json sidecar, or a headerNav entry pointing at a
+# category_no_page page (a site-wide 404 that --strict-broken cannot see).
+step "Category metadata check (check:category-meta)"
+if (cd "$ROOT_DIR" && pnpm check:category-meta); then
+  pass "Category metadata check passed"
+else
+  fail "Category metadata check"
+fi
+
+# ── Step 3: Template drift check ──────────────────────
 # Requires node_modules (reads create-zudo-doc devDep templates).
 # Run `pnpm install` first if this fails with "not found".
 step "Template drift check"
@@ -54,10 +67,10 @@ else
   fail "Template drift check"
 fi
 
-# ── Step 3: Pin parity check ──────────────────────────
+# ── Step 4: Pin parity check ──────────────────────────
 # Pure-Node: reads package.json only, no install needed.
 # Scripts check-pin-parity.mjs + check-wrangler-pin.mjs are provided by
-# the pin-guards sub-task (#68). Steps 3–4 will fail until that branch merges.
+# the pin-guards sub-task (#68). Steps 4–5 will fail until that branch merges.
 step "Pin parity check (check:pin-parity)"
 if (cd "$ROOT_DIR" && pnpm check:pin-parity); then
   pass "Pin parity check passed"
@@ -65,7 +78,7 @@ else
   fail "Pin parity check"
 fi
 
-# ── Step 4: Wrangler pin check ────────────────────────
+# ── Step 5: Wrangler pin check ────────────────────────
 # Requires node_modules (reads the zfb platform binary's embedded
 # EXPECTED_WRANGLER_VERSION). Catches a zfb bump that left the wrangler
 # pin stale, which would silently break local `zfb dev`/`preview`.
@@ -76,7 +89,7 @@ else
   fail "Wrangler pin check"
 fi
 
-# ── Step 5: Type checking ─────────────────────────────
+# ── Step 6: Type checking ─────────────────────────────
 step "Type checking (zfb check)"
 if (cd "$ROOT_DIR" && pnpm check); then
   pass "Type checking passed"
@@ -84,7 +97,7 @@ else
   fail "Type checking"
 fi
 
-# ── Step 6: Build ─────────────────────────────────────
+# ── Step 7: Build ─────────────────────────────────────
 step "Build (zfb build)"
 if (cd "$ROOT_DIR" && pnpm build); then
   pass "Build passed"
@@ -92,7 +105,7 @@ else
   fail "Build"
 fi
 
-# ── Step 7: HTML validation ───────────────────────────
+# ── Step 8: HTML validation ───────────────────────────
 step "HTML validation (html-validate)"
 if [[ "${B4PUSH_SKIP_HTML_VALIDATE:-}" == "1" ]]; then
   skip "HTML validation (B4PUSH_SKIP_HTML_VALIDATE=1)"
@@ -104,7 +117,7 @@ else
   fi
 fi
 
-# ── Step 8: Link check ───────────────────────────────
+# ── Step 9: Link check ───────────────────────────────
 step "Link check (check:links)"
 if [[ "${B4PUSH_SKIP_LINK_CHECK:-}" == "1" ]]; then
   skip "Link check (B4PUSH_SKIP_LINK_CHECK=1)"


### PR DESCRIPTION
## Summary

Three coordinated changes, applied family-wide across the `*-wisdom` repos.

**1. Dependency bump.** `@takazudo/zudo-doc`, `@takazudo/zudo-doc-history-server`, and the `create-zudo-doc` devDependency go from `^4.2.1` to `^4.4.13` (npm `latest`). The `@takazudo/zfb*` pins stay at `0.1.0-next.89` and `@takazudo/zdtp` stays at `0.4.9`, deliberately.

> [!NOTE]
> zudo-doc 4.4.13 declares a **non-optional peer** of `@takazudo/zfb ^0.1.0-next.99`, which the `next.89` pin does not satisfy. pnpm tolerates this silently (`strict-peer-dependencies` is off), and install, `tsc`, and the 131-page build are all green against `next.89`. Bumping zfb was explicitly out of scope, so the mismatch is recorded here rather than papered over.

**2. Category-metadata lint.** Adds `scripts/check-category-meta.mjs` — a byte-identical copy of the canonical `wisdom-tweaker/shared/scripts/` version, so all five wisdom repos stay in sync. It guards two failure modes nothing else can see:

- a stray `_category_.json` sidecar, silently ignored by zudo-doc under zfb, so its `label` / `position` / `noPage` are discarded with a green build;
- a `headerNav` entry pointing at a `category_no_page` page — a site-wide 404 that zfb's `--strict-broken` does not catch.

Exposed as `pnpm check:category-meta` and wired into `b4push` as **step 2**, among the cheap source-level checks: it is pure Node and needs neither `node_modules` nor a build. `TOTAL_STEPS` goes 8 -> 9 and the later step comments are renumbered.

**3. Template drift reconcile.** `pnpm check:template-drift` reports **zero drift** after the bump — but that is only meaningful if the allowlist is still accurate, so every entry was re-validated against the 4.4.13 templates instead of trusting the green exit:

| File | Outcome |
|---|---|
| `src/styles/global.css` | Still diverges (brand fonts/colors) — allowlist kept |
| `pages/index.tsx` | Still diverges (reconstructed wide home) — allowlist kept |
| `pages/docs/[[...slug]].tsx` | Still diverges (docHistory patch) — allowlist kept |
| `pages/[locale]/docs/[[...slug]].tsx` | Still diverges (docHistory patch) — allowlist kept |
| `scripts/setup-doc-skill.sh` | Still diverges (skill name + Codex target) — allowlist kept |
| `tsconfig.json` | Still byte-identical — correctly unlisted |

No file was overwritten and no new file was allowlisted. The `templates/base` file set and the feature dir set (`claudeSkills`, `i18n`, `tauri`, `tauriDev`) are both unchanged from 4.2.1, so `check-template-drift.sh`'s `for feature in i18n` loop still scans the right feature and needed no adjustment.

`setup-doc-skill.sh` is the only template whose *content* changed between 4.2.1 and 4.4.13 (upstream added `PROJECT_PREFIX` / `MAIN_PROJECT_DIR` nested-project and worktree correctness). Our fork predates it and has deliberately **not** adopted it — re-forking a heavily customized file is out of scope for this bump, so it is documented in place in the allowlist.

The allowlist header was also corrected: it claimed `pages/index.tsx` was byte-identical and unlisted, which has been false since the wide-home-page change.

## Test Plan

`pnpm b4push` passes fully — all 9 steps green, no `B4PUSH_SKIP_*` overrides:

```
Step 1/9 Format check          Step 6/9 Type checking (zfb check)
Step 2/9 Category metadata     Step 7/9 Build (131 pages)
Step 3/9 Template drift        Step 8/9 HTML validation
Step 4/9 Pin parity            Step 9/9 Link check
Step 5/9 Wrangler pin
```

Additionally verified in a browser against `pnpm preview`: home and doc pages render with **0 page errors**, the wide home layout and all 9 `headerNav` entries are intact, and every nav target plus the `ja` locale route returns 200 — independently confirming the new lint's no-nav-404 premise.