### PR TITLE
Revert zudo-doc 4.4.13 bump and template-drift reconcile (keep the category-metadata lint)

### DIFF
--- a/.template-drift-allowlist
+++ b/.template-drift-allowlist
@@ -11,15 +11,8 @@
 # 4.x create-zudo-doc templates/base ships only pages/index.tsx,
 # pages/docs/[[...slug]].tsx, scripts/setup-doc-skill.sh, src/styles/global.css,
 # tsconfig.json (+ the i18n feature's pages/[locale]/docs/[[...slug]].tsx). Of
-# those, only tsconfig.json is byte-identical to the template (NOT listed); the
-# five below diverge intentionally.
-#
-# Re-validated against create-zudo-doc 4.4.13 (up from 4.2.1): the base file set
-# and the feature directory set (claudeSkills, i18n, tauri, tauriDev) are both
-# unchanged, every entry below still genuinely diverges for the reason stated,
-# and tsconfig.json is still byte-identical. The only template that changed
-# content between 4.2.1 and 4.4.13 is scripts/setup-doc-skill.sh — see its
-# section below.
+# those, tsconfig.json and pages/index.tsx are byte-identical to the template
+# (NOT listed); the four below diverge intentionally.
 
 # ── Host customization: brand + tight-token global.css ────────────────────
 # global.css carries this site's font overrides (Noto Sans JP body + Futura
@@ -40,16 +33,6 @@ pages/[locale]/docs/[[...slug]].tsx
 # scripts/setup-doc-skill.sh is customized with this site's skill name
 # (tauri-wisdom) and Claude + Codex targets, so it diverges from the template
 # default. The skill it emits is gitignored.
-#
-# NOTE (4.4.13): this is the one template whose content changed since 4.2.1.
-# Upstream added nested-project / worktree correctness — PROJECT_PREFIX,
-# REPO_DOCS_DIR, MAIN_PROJECT_DIR and package.json-driven format-script
-# detection (zudolab/zudo-doc#2918) — so the emitted SKILL.md points at the main
-# worktree's project dir instead of the current worktree. Our fork predates all
-# of that and still hard-codes `$REPO_ROOT/src/content/docs` and `pnpm
-# format:md`. Deliberately NOT adopted here: porting it means re-forking a
-# heavily customized file, which is out of scope for the 4.4.13 bump. Tracked
-# separately so it is not lost.
 scripts/setup-doc-skill.sh
 
 # ── Wide home page override (css-wisdom PR #182 parity) ──

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@takazudo/zfb-runtime": "0.1.0-next.89",
     "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.89",
     "@takazudo/zfb-md-wasm": "0.1.0-next.89",
-    "@takazudo/zudo-doc": "^4.4.13",
+    "@takazudo/zudo-doc": "^4.2.1",
     "zod": "^4.3.6",
     "preact": "^10.29.1",
     "preact-render-to-string": "^6.6.6",
@@ -50,7 +50,7 @@
     "diff": "^8.0.3",
     "@takazudo/zdtp": "0.4.9",
     "minisearch": "^7.2.0",
-    "@takazudo/zudo-doc-history-server": "^4.4.13"
+    "@takazudo/zudo-doc-history-server": "^4.2.1"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.0",
@@ -58,7 +58,7 @@
     "typescript": "^5.9.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.2.0",
-    "create-zudo-doc": "^4.4.13",
+    "create-zudo-doc": "^4.2.1",
     "html-validate": "^10.0.0",
     "pagefind": "^1.4.0",
     "npm-run-all2": "^7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,11 +27,11 @@ importers:
         specifier: 0.1.0-next.89
         version: 0.1.0-next.89(@takazudo/zfb@0.1.0-next.89)
       '@takazudo/zudo-doc':
-        specifier: ^4.4.13
-        version: 4.4.13(@takazudo/zdtp@0.4.9(preact@10.29.2))(@takazudo/zfb-md-wasm@0.1.0-next.89)(@takazudo/zfb-runtime@0.1.0-next.89(@takazudo/zfb@0.1.0-next.89))(@takazudo/zfb@0.1.0-next.89)(@takazudo/zudo-doc-history-server@4.4.13)(@types/node@22.19.21)(diff@8.0.4)(katex@0.16.47)(preact@10.29.2)(zod@4.4.3)
+        specifier: ^4.2.1
+        version: 4.2.1(@takazudo/zdtp@0.4.9(preact@10.29.2))(@takazudo/zfb-md-wasm@0.1.0-next.89)(@takazudo/zfb-runtime@0.1.0-next.89(@takazudo/zfb@0.1.0-next.89))(@takazudo/zfb@0.1.0-next.89)(@takazudo/zudo-doc-history-server@4.2.1)(@types/node@22.19.21)(diff@8.0.4)(katex@0.16.47)(preact@10.29.2)(shiki@4.2.0)(zod@4.4.3)
       '@takazudo/zudo-doc-history-server':
-        specifier: ^4.4.13
-        version: 4.4.13
+        specifier: ^4.2.1
+        version: 4.2.1
       diff:
         specifier: ^8.0.3
         version: 8.0.4
@@ -76,8 +76,8 @@ importers:
         specifier: ^19.2.0
         version: 19.2.17
       create-zudo-doc:
-        specifier: ^4.4.13
-        version: 4.4.13
+        specifier: ^4.2.1
+        version: 4.2.1
       html-validate:
         specifier: ^10.0.0
         version: 10.17.0
@@ -1161,22 +1161,23 @@ packages:
       react:
         optional: true
 
-  '@takazudo/zudo-doc-history-server@4.4.13':
-    resolution: {integrity: sha512-+gN80sd69kJkdMD8SZzXYg6RN7F4unO27xmRUicyCUjdTtD0ENYPo3HaEYgu0sgEJ9qwtejc6yF1Tju5spD4jw==}
+  '@takazudo/zudo-doc-history-server@4.2.1':
+    resolution: {integrity: sha512-qpG0h2JUglWdfLbY7FqHzRhsUwV/QT3Ztw/FnItyZ4Zoywu1Flchv9hS7MaQkx27t7PjLmf8U1fcRe0ZkK42iw==}
     hasBin: true
 
-  '@takazudo/zudo-doc@4.4.13':
-    resolution: {integrity: sha512-76k2H0xsU3ifA7YPQPJIS7yJGEgSkBNN7p+w518DzxLHqOI2Y5ZLyJueF5kyHajqA+mlY8zd/Wlp6EJ3pHzJGQ==}
+  '@takazudo/zudo-doc@4.2.1':
+    resolution: {integrity: sha512-PocAovdxqoBtP7eUO21zihvrFxduK11uh3aWIOzUvZuAMGqyfsoZsv/tMYiBHcwexCWNzvkmaZhsCOX3E4nbNw==}
     hasBin: true
     peerDependencies:
       '@takazudo/zdtp': ^0.4.9
-      '@takazudo/zfb': ^0.1.0-next.99
-      '@takazudo/zfb-md-wasm': ^0.1.0-next.99
-      '@takazudo/zfb-runtime': ^0.1.0-next.99
-      '@takazudo/zudo-doc-history-server': ^4.4.11
+      '@takazudo/zfb': ^0.1.0-next.89
+      '@takazudo/zfb-md-wasm': ^0.1.0-next.89
+      '@takazudo/zfb-runtime': ^0.1.0-next.89
+      '@takazudo/zudo-doc-history-server': ^4.0.0
       diff: ^8.0.0
       katex: ^0.16.0
       preact: ^10.29.1
+      shiki: ^4.0.2
       zod: ^4.3.6
     peerDependenciesMeta:
       '@takazudo/zdtp':
@@ -1188,6 +1189,8 @@ packages:
       diff:
         optional: true
       katex:
+        optional: true
+      shiki:
         optional: true
 
   '@tybys/wasm-util@0.10.2':
@@ -1395,8 +1398,8 @@ packages:
   cose-base@2.2.0:
     resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
 
-  create-zudo-doc@4.4.13:
-    resolution: {integrity: sha512-66XqqePHfdI4X5sgAtIuDSOdYWYTjcVV9be2SbwkDG9iFLPYzab7vqU2b1c7nvKIBtaRmxVBqXa7nhzoMfiHpw==}
+  create-zudo-doc@4.2.1:
+    resolution: {integrity: sha512-AimkdpuBuahsmqzzDgyq4LjZsOIxS5XldFKS+8wJ5o9lYf180GDFSJbLN2xNYH2CKTVpty9nwNMcEThwOXfQuQ==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -3159,9 +3162,9 @@ snapshots:
       '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.89
       '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.89
 
-  '@takazudo/zudo-doc-history-server@4.4.13': {}
+  '@takazudo/zudo-doc-history-server@4.2.1': {}
 
-  '@takazudo/zudo-doc@4.4.13(@takazudo/zdtp@0.4.9(preact@10.29.2))(@takazudo/zfb-md-wasm@0.1.0-next.89)(@takazudo/zfb-runtime@0.1.0-next.89(@takazudo/zfb@0.1.0-next.89))(@takazudo/zfb@0.1.0-next.89)(@takazudo/zudo-doc-history-server@4.4.13)(@types/node@22.19.21)(diff@8.0.4)(katex@0.16.47)(preact@10.29.2)(zod@4.4.3)':
+  '@takazudo/zudo-doc@4.2.1(@takazudo/zdtp@0.4.9(preact@10.29.2))(@takazudo/zfb-md-wasm@0.1.0-next.89)(@takazudo/zfb-runtime@0.1.0-next.89(@takazudo/zfb@0.1.0-next.89))(@takazudo/zfb@0.1.0-next.89)(@takazudo/zudo-doc-history-server@4.2.1)(@types/node@22.19.21)(diff@8.0.4)(katex@0.16.47)(preact@10.29.2)(shiki@4.2.0)(zod@4.4.3)':
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@22.19.21)
       '@takazudo/zfb': 0.1.0-next.89
@@ -3178,9 +3181,10 @@ snapshots:
     optionalDependencies:
       '@takazudo/zdtp': 0.4.9(preact@10.29.2)
       '@takazudo/zfb-md-wasm': 0.1.0-next.89
-      '@takazudo/zudo-doc-history-server': 4.4.13
+      '@takazudo/zudo-doc-history-server': 4.2.1
       diff: 8.0.4
       katex: 0.16.47
+      shiki: 4.2.0
     transitivePeerDependencies:
       - '@types/node'
 
@@ -3403,7 +3407,7 @@ snapshots:
     dependencies:
       layout-base: 2.0.1
 
-  create-zudo-doc@4.4.13:
+  create-zudo-doc@4.2.1:
     dependencies:
       '@clack/prompts': 0.9.1
       fs-extra: 11.3.5


### PR DESCRIPTION
## Why

PR #57 landed three changes together. Two of them must come back off `main`:

zudo-doc 4.4.13 peer-requires `@takazudo/zfb ^0.1.0-next.99`, while every wisdom repo pins the zfb family at `0.1.0-next.89`. pnpm tolerates the mismatch silently (`strict-peer-dependencies` is off) and the build stays green, which is exactly why it slipped through — but it is a real incompatibility across all five repos, and the zfb decision sits with the user. Holding the bump rather than working around it.

## What this reverts

- `f328885` — the zudo-doc family bump. Back to `^4.2.1` for `@takazudo/zudo-doc`, `@takazudo/zudo-doc-history-server`, and the `create-zudo-doc` devDependency. `@takazudo/zfb*` and `@takazudo/zdtp` were never touched and are still untouched.
- `f974a65` — the template-drift allowlist re-validation. `create-zudo-doc`'s templates *are* the drift baseline, and that baseline moves with the version. Re-validating against 4.4.13 is meaningless while we sit on 4.2.1, and the notes it added would be actively misleading.

## What this deliberately keeps

The **category-metadata lint** stays. It is fully decoupled from the dependency graph — pure Node, no `node_modules`, no build — so the zfb question does not block it:

- `scripts/check-category-meta.mjs` (byte-identical to the canonical `wisdom-tweaker/shared/scripts/` copy)
- the `check:category-meta` package script
- its wiring as **b4push step 2**, with `TOTAL_STEPS` at 9

## Test Plan

`pnpm install` returns cleanly to 4.2.1 — and unlike the 4.4.13 install, this one is **peer-clean**: 4.2.1 peers `zfb ^0.1.0-next.89`, which matches our pin exactly.

`pnpm b4push` passes all 9 steps at 4.2.1, no `B4PUSH_SKIP_*` overrides:

```
Step 1/9 Format check          Step 6/9 Type checking (zfb check)
Step 2/9 Category metadata     Step 7/9 Build
Step 3/9 Template drift        Step 8/9 HTML validation
Step 4/9 Pin parity            Step 9/9 Link check
Step 5/9 Wrangler pin
```

## Known gap re-introduced

Reverting `f974a65` restores an allowlist header that claims `pages/index.tsx` is byte-identical to the template and therefore unlisted. That has been false since the wide-home-page change — the file is listed and does diverge. Left as-is here to keep the revert clean; the bug is independent of the zudo-doc version and can be fixed on its own.