### PR TITLE
chore: bump zfb to next.99 + zudo-doc to 4.4.13, re-sync v2 guard scripts, gate category metadata in CI

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -3,6 +3,7 @@
 # Triggered on PRs targeting `main`. The pipeline:
 #   1. Template drift check (needs pnpm install — create-zudo-doc devDep)
 #   2. Pin parity check (pure-Node, reads package.json only)
+#   2.5. Category metadata check (pure-Node, reads src/ + zfb.config.ts)
 #   3. Format check (pnpm format:md:check — pnpm dlx, no install needed)
 #   4. Type check (pnpm check) + wrangler pin check
 #   5. Build the zfb docs site (full clone) + link check
@@ -80,6 +81,31 @@ jobs:
 
       - name: Check pin parity
         run: node scripts/check-pin-parity.mjs
+
+  # ---------------------------------------------------------------------------
+  # Job 0.55: Category metadata check
+  # ---------------------------------------------------------------------------
+  # Pure-Node script — reads src/ and zfb.config.ts only, no pnpm install needed.
+  # Catches category metadata that zudo-doc silently discards under zfb: a stray
+  # _category_.json sidecar, or a headerNav entry pointing at a page marked
+  # category_no_page (a site-wide 404 that check:links --strict-broken does not
+  # catch, so no other job here would fail on it).
+  check-category-meta:
+    name: Category Metadata Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 22
+
+      - name: Check category metadata
+        run: node scripts/check-category-meta.mjs
 
   # ---------------------------------------------------------------------------
   # Job 0.6: Format check

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -103,6 +103,12 @@ jobs:
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
+          # This job deliberately skips `pnpm install`, so pnpm is never set up.
+          # setup-node defaults package-manager-cache to true, which probes for
+          # the repo's package manager and hard-fails with "Unable to locate
+          # executable file: pnpm". Disable the probe rather than adding a pnpm
+          # setup step we would otherwise have no use for.
+          package-manager-cache: false
 
       - name: Check category metadata
         run: node scripts/check-category-meta.mjs

--- a/.template-drift-allowlist
+++ b/.template-drift-allowlist
@@ -11,8 +11,16 @@
 # 4.x create-zudo-doc templates/base ships only pages/index.tsx,
 # pages/docs/[[...slug]].tsx, scripts/setup-doc-skill.sh, src/styles/global.css,
 # tsconfig.json (+ the i18n feature's pages/[locale]/docs/[[...slug]].tsx). Of
-# those, tsconfig.json and pages/index.tsx are byte-identical to the template
-# (NOT listed); the four below diverge intentionally.
+# those, only tsconfig.json is byte-identical to the template (NOT listed); the
+# five below diverge intentionally.
+#
+# Re-validated against create-zudo-doc 4.4.13 (up from 4.2.1): the base file set
+# and the feature directory set (claudeSkills, i18n, tauri, tauriDev) are both
+# unchanged, so check-template-drift.sh's `for feature in i18n` loop still scans
+# the right feature. Every entry below still genuinely diverges for the reason
+# stated, and tsconfig.json is still byte-identical. The only template whose
+# content changed between 4.2.1 and 4.4.13 is scripts/setup-doc-skill.sh — see
+# its section below.
 
 # ── Host customization: brand + tight-token global.css ────────────────────
 # global.css carries this site's font overrides (Noto Sans JP body + Futura
@@ -33,9 +41,21 @@ pages/[locale]/docs/[[...slug]].tsx
 # scripts/setup-doc-skill.sh is customized with this site's skill name
 # (tauri-wisdom) and Claude + Codex targets, so it diverges from the template
 # default. The skill it emits is gitignored.
+#
+# NOTE (4.4.13): this is the one template whose content changed since 4.2.1.
+# Upstream added nested-project / worktree correctness — PROJECT_PREFIX,
+# REPO_DOCS_DIR, MAIN_PROJECT_DIR and package.json-driven format-script
+# detection (zudolab/zudo-doc#2918) — so the emitted SKILL.md points at the main
+# worktree's project dir instead of the current worktree. Our fork predates all
+# of that and still hard-codes `$REPO_ROOT/src/content/docs` and `pnpm
+# format:md`. Deliberately NOT adopted here: porting it means re-forking a
+# heavily customized file, which is a separate piece of work from a version
+# bump. Recorded so it is not silently lost.
 scripts/setup-doc-skill.sh
 
 # ── Wide home page override (css-wisdom PR #182 parity) ──
 # pages/index.tsx is reconstructed to render HomePageView with `wide` (zudo-doc
-# 4.2.1 has no config toggle), diverging from the locked 1-line re-export.
+# has no config toggle for this), diverging from the locked 1-line re-export.
+# Still required on 4.4.13 — the base template for this file is byte-identical
+# between 4.2.1 and 4.4.13, so upstream has not added a toggle to adopt.
 pages/index.tsx

--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
     "setup:doc-skill:both": "bash scripts/setup-doc-skill.sh --target both"
   },
   "dependencies": {
-    "@takazudo/zfb": "0.1.0-next.89",
-    "@takazudo/zfb-runtime": "0.1.0-next.89",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.89",
-    "@takazudo/zfb-md-wasm": "0.1.0-next.89",
-    "@takazudo/zudo-doc": "^4.2.1",
+    "@takazudo/zfb": "0.1.0-next.99",
+    "@takazudo/zfb-runtime": "0.1.0-next.99",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.99",
+    "@takazudo/zfb-md-wasm": "0.1.0-next.99",
+    "@takazudo/zudo-doc": "^4.4.13",
     "zod": "^4.3.6",
     "preact": "^10.29.1",
     "preact-render-to-string": "^6.6.6",
@@ -50,7 +50,7 @@
     "diff": "^8.0.3",
     "@takazudo/zdtp": "0.4.9",
     "minisearch": "^7.2.0",
-    "@takazudo/zudo-doc-history-server": "^4.2.1"
+    "@takazudo/zudo-doc-history-server": "^4.4.13"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.0",
@@ -58,7 +58,7 @@
     "typescript": "^5.9.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.2.0",
-    "create-zudo-doc": "^4.2.1",
+    "create-zudo-doc": "^4.4.13",
     "html-validate": "^10.0.0",
     "pagefind": "^1.4.0",
     "npm-run-all2": "^7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,23 +15,23 @@ importers:
         specifier: 0.4.9
         version: 0.4.9(preact@10.29.2)
       '@takazudo/zfb':
-        specifier: 0.1.0-next.89
-        version: 0.1.0-next.89
+        specifier: 0.1.0-next.99
+        version: 0.1.0-next.99
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.89
-        version: 0.1.0-next.89
+        specifier: 0.1.0-next.99
+        version: 0.1.0-next.99
       '@takazudo/zfb-md-wasm':
-        specifier: 0.1.0-next.89
-        version: 0.1.0-next.89
+        specifier: 0.1.0-next.99
+        version: 0.1.0-next.99
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.89
-        version: 0.1.0-next.89(@takazudo/zfb@0.1.0-next.89)
+        specifier: 0.1.0-next.99
+        version: 0.1.0-next.99(@takazudo/zfb@0.1.0-next.99)
       '@takazudo/zudo-doc':
-        specifier: ^4.2.1
-        version: 4.2.1(@takazudo/zdtp@0.4.9(preact@10.29.2))(@takazudo/zfb-md-wasm@0.1.0-next.89)(@takazudo/zfb-runtime@0.1.0-next.89(@takazudo/zfb@0.1.0-next.89))(@takazudo/zfb@0.1.0-next.89)(@takazudo/zudo-doc-history-server@4.2.1)(@types/node@22.19.21)(diff@8.0.4)(katex@0.16.47)(preact@10.29.2)(shiki@4.2.0)(zod@4.4.3)
+        specifier: ^4.4.13
+        version: 4.4.13(@takazudo/zdtp@0.4.9(preact@10.29.2))(@takazudo/zfb-md-wasm@0.1.0-next.99)(@takazudo/zfb-runtime@0.1.0-next.99(@takazudo/zfb@0.1.0-next.99))(@takazudo/zfb@0.1.0-next.99)(@takazudo/zudo-doc-history-server@4.4.13)(@types/node@22.19.21)(diff@8.0.4)(katex@0.16.47)(preact@10.29.2)(zod@4.4.3)
       '@takazudo/zudo-doc-history-server':
-        specifier: ^4.2.1
-        version: 4.2.1
+        specifier: ^4.4.13
+        version: 4.4.13
       diff:
         specifier: ^8.0.3
         version: 8.0.4
@@ -76,8 +76,8 @@ importers:
         specifier: ^19.2.0
         version: 19.2.17
       create-zudo-doc:
-        specifier: ^4.2.1
-        version: 4.2.1
+        specifier: ^4.4.13
+        version: 4.4.13
       html-validate:
         specifier: ^10.0.0
         version: 10.17.0
@@ -1107,52 +1107,52 @@ packages:
     peerDependencies:
       preact: ^10.29.1
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.89':
-    resolution: {integrity: sha512-DPKPaL7ytjhrCOlWqqGea4nVgLbhle7HdKlwx118oBM9hu53eHl2Cww2/JZqKMDwmkaTzKVI4y8babOexepnig==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.99':
+    resolution: {integrity: sha512-DJHPHxcc3xpXi0pY3+Wa85BRvaZifFI0vJZ2VxvqfWmK6j3Gxl8Uh03YHGRV/Hzx3my8Ki27qjgVhxAI1aAhrw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.89':
-    resolution: {integrity: sha512-zJjugYxLGfqM8FPapJLx42KgZD5+Z+gxqjmAK3YhtbO6x8sRoVZQwODfsPBqozOB75vv0Qwr9YqmMlR58ScV0A==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.99':
+    resolution: {integrity: sha512-pGB1tBOYSiNfCxPewE19iTVOMlJi1b7cWai7P3e/Q8YoeXvpA+bg1aP6JsFmhlfkARk8N/EIpBKJ2TdawS2lmA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.89':
-    resolution: {integrity: sha512-hJZmGdh2AM/KehijWa2PZWSwzvv/gQFkaLwnvook0UWlHVxcSTyQ/vvJnls+h71thZ0Y4HBYqyjz9JLZ44eIYA==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.99':
+    resolution: {integrity: sha512-UwglM04XmxrS0kiBvEzTnUUDsEqxak5rB6B/6J+WVtRHmpyRpYmqD4lTmHs35OjMgP0Xj3VjA1Twfkqpw38ByA==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.89':
-    resolution: {integrity: sha512-byl6MxCNdNf5rMVZcK22P9cdelNswsUyGuK0TleVatH5ZlWcWzRPAw6xnNqoOp8Vi4NvL/IvlMMebMHlu3UZBQ==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.99':
+    resolution: {integrity: sha512-M1Kymo9raU4oI6AaBV8IKX9TQW07MmuHcWK0gMWiTF/FsM725JkD78gpnl4SdbKqfyJCc83l8WDY97Z/yLjFLA==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.89':
-    resolution: {integrity: sha512-U6qIsX0nR0Utjuoaw+aeSvgPwpH1hgeSEfgtBz9GgxHmh9CR1fN7QCz+OlRH/cOZmGbnqCkyPekdU3BaIV3/3A==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.99':
+    resolution: {integrity: sha512-JuYzJtmVfIst+RH8hqjL5/dz0nL2zkqWz7bTZ6X2j1SYvdZhMrB1A4n4sRH5x4Ihv3eDwjEahz7TJmhK6mjTjA==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-md-wasm@0.1.0-next.89':
-    resolution: {integrity: sha512-vVmKCyQMQ5I5WMSLwXvLYaUb6ac2DJw4FguiQWsA36LCccTBjS7F8PrpOSdDmIY4+ujshIdKiR0SddCGGjs8vg==}
+  '@takazudo/zfb-md-wasm@0.1.0-next.99':
+    resolution: {integrity: sha512-wKA3JE5MpdIhSzgCY+6FkBoJq1zd459oywVzPclk3D6XHO/RLjmvhPfTeQyNB2R2vT9z0ATY2lrYNNPpZ4BUww==}
     engines: {node: '>=20.0.0', pnpm: '>=10.0.0'}
 
-  '@takazudo/zfb-runtime@0.1.0-next.89':
-    resolution: {integrity: sha512-lQuJ65mmydyMulGT0bugFuRRLk+qGfQUAfqWNZsLxF5012ZL+L4ZEELBzzfA+oKlXrfi2HTzbmEChLC4I7X9iA==}
+  '@takazudo/zfb-runtime@0.1.0-next.99':
+    resolution: {integrity: sha512-X6WfSImstjKJoFXtsfQBC0/AdVH0lfFm6zjmM9xAg6j/fwLgXBlen2ZeLGIaHNt4nsTvTfbwoUAq++ltE68+4A==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.89
+      '@takazudo/zfb': 0.1.0-next.99
       react: ^19.2.3
     peerDependenciesMeta:
       react:
         optional: true
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.89':
-    resolution: {integrity: sha512-zgjKX9EaL6QD4PSs3qrDSSnpRSzt2RiGOeb5zJeeGVaiu4tyRmnjb/0XcLPq3eyw6yU/j6emUJ2dI6mKsbLD/Q==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.99':
+    resolution: {integrity: sha512-9/Uocff82fAClQVGo5uPzgvvks5+U2NvHDWpEEL92PatfP+9LLInBoEOGqrr7i5TtL+mq9T6JCodthHFitg+WQ==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.89':
-    resolution: {integrity: sha512-ptxbO8k+Y3mrXek8oT/2OZsd24QP4RKcwUgz6bZwWsKMKRXaw8k8ojPGSY0EVRcVLqrt17jxwaN3XS2Qp51YrA==}
+  '@takazudo/zfb@0.1.0-next.99':
+    resolution: {integrity: sha512-h4iAmYwFq8/vvS9256PzWyVGBJ2dVRJ1J3IB7SvexxDFrHWuM4cK9Gp+J/IUMS5mYlv0dSI6q4c8zrqBtVnzoQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
     peerDependencies:
@@ -1161,23 +1161,22 @@ packages:
       react:
         optional: true
 
-  '@takazudo/zudo-doc-history-server@4.2.1':
-    resolution: {integrity: sha512-qpG0h2JUglWdfLbY7FqHzRhsUwV/QT3Ztw/FnItyZ4Zoywu1Flchv9hS7MaQkx27t7PjLmf8U1fcRe0ZkK42iw==}
+  '@takazudo/zudo-doc-history-server@4.4.13':
+    resolution: {integrity: sha512-+gN80sd69kJkdMD8SZzXYg6RN7F4unO27xmRUicyCUjdTtD0ENYPo3HaEYgu0sgEJ9qwtejc6yF1Tju5spD4jw==}
     hasBin: true
 
-  '@takazudo/zudo-doc@4.2.1':
-    resolution: {integrity: sha512-PocAovdxqoBtP7eUO21zihvrFxduK11uh3aWIOzUvZuAMGqyfsoZsv/tMYiBHcwexCWNzvkmaZhsCOX3E4nbNw==}
+  '@takazudo/zudo-doc@4.4.13':
+    resolution: {integrity: sha512-76k2H0xsU3ifA7YPQPJIS7yJGEgSkBNN7p+w518DzxLHqOI2Y5ZLyJueF5kyHajqA+mlY8zd/Wlp6EJ3pHzJGQ==}
     hasBin: true
     peerDependencies:
       '@takazudo/zdtp': ^0.4.9
-      '@takazudo/zfb': ^0.1.0-next.89
-      '@takazudo/zfb-md-wasm': ^0.1.0-next.89
-      '@takazudo/zfb-runtime': ^0.1.0-next.89
-      '@takazudo/zudo-doc-history-server': ^4.0.0
+      '@takazudo/zfb': ^0.1.0-next.99
+      '@takazudo/zfb-md-wasm': ^0.1.0-next.99
+      '@takazudo/zfb-runtime': ^0.1.0-next.99
+      '@takazudo/zudo-doc-history-server': ^4.4.11
       diff: ^8.0.0
       katex: ^0.16.0
       preact: ^10.29.1
-      shiki: ^4.0.2
       zod: ^4.3.6
     peerDependenciesMeta:
       '@takazudo/zdtp':
@@ -1189,8 +1188,6 @@ packages:
       diff:
         optional: true
       katex:
-        optional: true
-      shiki:
         optional: true
 
   '@tybys/wasm-util@0.10.2':
@@ -1291,6 +1288,12 @@ packages:
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
@@ -1398,8 +1401,8 @@ packages:
   cose-base@2.2.0:
     resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
 
-  create-zudo-doc@4.2.1:
-    resolution: {integrity: sha512-AimkdpuBuahsmqzzDgyq4LjZsOIxS5XldFKS+8wJ5o9lYf180GDFSJbLN2xNYH2CKTVpty9nwNMcEThwOXfQuQ==}
+  create-zudo-doc@4.4.13:
+    resolution: {integrity: sha512-66XqqePHfdI4X5sgAtIuDSOdYWYTjcVV9be2SbwkDG9iFLPYzab7vqU2b1c7nvKIBtaRmxVBqXa7nhzoMfiHpw==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -1909,6 +1912,18 @@ packages:
 
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdx@3.0.0:
+    resolution: {integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
 
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
@@ -3130,45 +3145,51 @@ snapshots:
       preact: 10.29.2
       tailwind-merge: 3.6.0
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.89': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.99': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.89':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.99':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.89':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.99':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.89':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.99':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.89':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.99':
     optional: true
 
-  '@takazudo/zfb-md-wasm@0.1.0-next.89': {}
-
-  '@takazudo/zfb-runtime@0.1.0-next.89(@takazudo/zfb@0.1.0-next.89)':
+  '@takazudo/zfb-md-wasm@0.1.0-next.99':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.89
+      '@types/mdast': 4.0.4
+      mdast-util-directive: 3.1.0
+      mdast-util-mdx: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@takazudo/zfb-runtime@0.1.0-next.99(@takazudo/zfb@0.1.0-next.99)':
+    dependencies:
+      '@takazudo/zfb': 0.1.0-next.99
       hono: 4.12.25
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.89':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.99':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.89':
+  '@takazudo/zfb@0.1.0-next.99':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.89
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.89
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.89
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.89
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.89
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.99
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.99
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.99
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.99
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.99
 
-  '@takazudo/zudo-doc-history-server@4.2.1': {}
+  '@takazudo/zudo-doc-history-server@4.4.13': {}
 
-  '@takazudo/zudo-doc@4.2.1(@takazudo/zdtp@0.4.9(preact@10.29.2))(@takazudo/zfb-md-wasm@0.1.0-next.89)(@takazudo/zfb-runtime@0.1.0-next.89(@takazudo/zfb@0.1.0-next.89))(@takazudo/zfb@0.1.0-next.89)(@takazudo/zudo-doc-history-server@4.2.1)(@types/node@22.19.21)(diff@8.0.4)(katex@0.16.47)(preact@10.29.2)(shiki@4.2.0)(zod@4.4.3)':
+  '@takazudo/zudo-doc@4.4.13(@takazudo/zdtp@0.4.9(preact@10.29.2))(@takazudo/zfb-md-wasm@0.1.0-next.99)(@takazudo/zfb-runtime@0.1.0-next.99(@takazudo/zfb@0.1.0-next.99))(@takazudo/zfb@0.1.0-next.99)(@takazudo/zudo-doc-history-server@4.4.13)(@types/node@22.19.21)(diff@8.0.4)(katex@0.16.47)(preact@10.29.2)(zod@4.4.3)':
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@22.19.21)
-      '@takazudo/zfb': 0.1.0-next.89
-      '@takazudo/zfb-runtime': 0.1.0-next.89(@takazudo/zfb@0.1.0-next.89)
+      '@takazudo/zfb': 0.1.0-next.99
+      '@takazudo/zfb-runtime': 0.1.0-next.99(@takazudo/zfb@0.1.0-next.99)
       fs-extra: 11.3.5
       gray-matter: 4.0.3
       minimist: 1.2.8
@@ -3180,11 +3201,10 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       '@takazudo/zdtp': 0.4.9(preact@10.29.2)
-      '@takazudo/zfb-md-wasm': 0.1.0-next.89
-      '@takazudo/zudo-doc-history-server': 4.2.1
+      '@takazudo/zfb-md-wasm': 0.1.0-next.99
+      '@takazudo/zudo-doc-history-server': 4.4.13
       diff: 8.0.4
       katex: 0.16.47
-      shiki: 4.2.0
     transitivePeerDependencies:
       - '@types/node'
 
@@ -3314,6 +3334,12 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.9
+
+  '@types/estree@1.0.9': {}
+
   '@types/geojson@7946.0.16': {}
 
   '@types/hast@3.0.4':
@@ -3407,7 +3433,7 @@ snapshots:
     dependencies:
       layout-base: 2.0.1
 
-  create-zudo-doc@4.2.1:
+  create-zudo-doc@4.4.13:
     dependencies:
       '@clack/prompts': 0.9.1
       fs-extra: 11.3.5
@@ -3945,6 +3971,55 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
       unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx@3.0.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 

--- a/scripts/check-category-meta.mjs
+++ b/scripts/check-category-meta.mjs
@@ -27,27 +27,49 @@
  *   1. FAIL on any `_category_.json` under src/. Upstream retired the sidecar in
  *      favour of index.mdx frontmatter; any remaining file is dead weight that
  *      reads as configuration but is silently ignored.
- *   2. FAIL when a `headerNav` entry targets a page with
- *      `category_no_page: true`. Suppressing a category that the header links to
- *      turns that link into a site-wide 404, and zfb's `--strict-broken` does
- *      NOT catch it (measured on the zfb docs site).
+ *   2. FAIL when a `headerNav` entry targets a page with `category_no_page:
+ *      true`, in the default locale OR in any configured locale. Suppressing a
+ *      category the header links to turns that link into a site-wide 404, and
+ *      zfb's `--strict-broken` does NOT catch it.
  *
- * Unresolvable headerNav paths are reported as warnings, not failures — the
- * path→file resolution below is a heuristic and must never fail a build on its
- * own uncertainty.
+ * ── A NOTE ON SELF-DEFEAT ─────────────────────────────────────────────────
+ * The first version of this script printed a green OK on a repo where it had
+ * parsed ZERO nav entries, because that repo declares `headerNav` in
+ * src/config/settings.ts and spreads it into zfb.config.ts — so the regex found
+ * nothing and "checked everything successfully" was indistinguishable from
+ * "checked nothing". A guard against silent false-greens that itself
+ * false-greens is worse than no guard, because it manufactures confidence.
+ *
+ * Two rules follow, and both must be preserved by anyone editing this file:
+ *   - ALWAYS report the counts actually inspected (sidecars scanned, nav entries
+ *     parsed, locales considered). A reader must be able to see "0 checked".
+ *   - Treat "found no headerNav at all" as a WARNING worth printing loudly, not
+ *     as success. Absence of findings is not evidence of correctness.
+ *
+ * Unresolvable nav paths are warnings, not failures — the path→file resolution
+ * is a heuristic and must not fail a build on its own uncertainty.
  *
  * Usage: node scripts/check-category-meta.mjs
  * Exit:  0 = OK (warnings allowed), 1 = violations found
  */
 
 import { readFile, readdir, access } from "node:fs/promises";
-import { join, relative } from "node:path";
+import { join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const ROOT = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
+// fileURLToPath, not .pathname — the latter keeps percent-escapes, so a checkout
+// under a path with spaces or non-ASCII silently resolves to a directory that
+// does not exist, walk() swallows the ENOENT, and the script exits 0 having
+// scanned nothing.
+const ROOT = fileURLToPath(new URL("..", import.meta.url)).replace(/[/\\]$/, "");
 const SRC = join(ROOT, "src");
 const CONFIG = join(ROOT, "zfb.config.ts");
+// headerNav may live directly in zfb.config.ts or in a settings module that the
+// config spreads. Both shapes exist across the wisdom repos.
+const CONFIG_SOURCES = [CONFIG, join(ROOT, "src", "config", "settings.ts")];
 
 const SKIP_DIRS = new Set(["node_modules", ".git", "dist", ".astro", ".zfb", ".zfb-build"]);
+const PAGE_EXTS = [".mdx", ".md"];
 
 async function exists(p) {
   try {
@@ -82,14 +104,22 @@ function frontmatter(source) {
   return m ? m[1] : "";
 }
 
+/**
+ * YAML truthiness for `category_no_page`. Accepts the spellings a YAML parser
+ * treats as true — `true`, `True`, `TRUE`, `yes`, `on` — and tolerates a
+ * trailing `# comment`. The original `:\s*true\s*$` form missed all of these
+ * and false-greened on exactly the dead nav link this check exists to catch.
+ */
 function hasNoPage(fm) {
-  return /^\s*category_no_page\s*:\s*true\s*$/m.test(fm);
+  const m = fm.match(/^\s*category_no_page\s*:\s*([^#\r\n]*)/m);
+  if (!m) return false;
+  return /^(true|yes|on)$/i.test(m[1].trim());
 }
 
 /**
- * Pull `path:` values out of the `headerNav: [ ... ]` array in zfb.config.ts.
- * Regex rather than a TS parse: the config is a plain literal in every wisdom
- * repo, and this script must stay dependency-free.
+ * Pull `path:` values out of a `headerNav: [ ... ]` array. Regex rather than a
+ * TS parse: the configs are plain literals and this script stays dependency-free.
+ * Returns [] when the file declares no headerNav.
  */
 function parseHeaderNav(source) {
   const start = source.indexOf("headerNav:");
@@ -109,8 +139,7 @@ function parseHeaderNav(source) {
     }
   }
   if (end === -1) return [];
-  const block = source.slice(open, end);
-  return [...block.matchAll(/path\s*:\s*["'`]([^"'`]+)["'`]/g)].map((m) => m[1]);
+  return [...source.slice(open, end).matchAll(/path\s*:\s*["'`]([^"'`]+)["'`]/g)].map((m) => m[1]);
 }
 
 function parseDocsDir(source) {
@@ -123,12 +152,55 @@ function parseBase(source) {
   return m ? m[1] : "/";
 }
 
+/**
+ * Parse `locales: { ja: { label: "JA", dir: "src/content/docs-ja" }, ... }`.
+ * A locale-only `category_no_page` suppresses that locale's route while the
+ * localized header link survives — the headline failure mode, and one the
+ * default-docsDir-only resolution was completely blind to.
+ */
+function parseLocales(source) {
+  const start = source.indexOf("locales:");
+  if (start === -1) return [];
+  const open = source.indexOf("{", start);
+  if (open === -1) return [];
+  let depth = 0;
+  let end = -1;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  if (end === -1) return [];
+  const block = source.slice(open, end);
+  return [...block.matchAll(/(\w+)\s*:\s*\{[^}]*?\bdir\s*:\s*["']([^"']+)["']/g)].map((m) => ({
+    locale: m[1],
+    dir: m[2],
+  }));
+}
+
 const failures = [];
 const warnings = [];
+const notes = [];
 
 // ── Check 1: no _category_.json sidecars ──────────────────────────────────
 const srcFiles = await walk(SRC);
-const sidecars = srcFiles.filter((f) => f.endsWith("/_category_.json"));
+// sep-aware so this also matches on Windows backslash paths.
+const sidecars = srcFiles.filter(
+  (f) => f.endsWith(`${sep}_category_.json`) || f.endsWith("/_category_.json"),
+);
+
+if (srcFiles.length === 0) {
+  warnings.push(
+    `[EMPTY-SCAN] no files found under ${relative(ROOT, SRC)}/ — the sidecar ` +
+      `check inspected nothing. Verify the repo layout; this is not a pass.`,
+  );
+}
+notes.push(`scanned ${srcFiles.length} source file(s) under ${relative(ROOT, SRC)}/`);
 
 for (const f of sidecars) {
   failures.push(
@@ -140,62 +212,106 @@ for (const f of sidecars) {
 }
 
 // ── Check 2: headerNav must not target a suppressed category ──────────────
-if (await exists(CONFIG)) {
-  const configSource = await readFile(CONFIG, "utf-8");
-  const navPaths = parseHeaderNav(configSource);
-  const docsDir = parseDocsDir(configSource);
-  const base = parseBase(configSource);
+let navPaths = [];
+let navSource = null;
+let docsDir = "src/content/docs";
+let base = "/";
+let locales = [];
 
-  for (const navPath of navPaths) {
-    // Strip the configured base prefix, then the leading route segment
-    // (`/docs`), leaving the docsDir-relative slug.
-    let slug = navPath;
-    if (base && base !== "/" && slug.startsWith(base)) slug = slug.slice(base.length);
-    slug = slug.replace(/^\/+/, "").replace(/\/+$/, "");
-    if (slug === "docs") slug = "";
-    else if (slug.startsWith("docs/")) slug = slug.slice("docs/".length);
+for (const candidate of CONFIG_SOURCES) {
+  if (!(await exists(candidate))) continue;
+  const source = await readFile(candidate, "utf-8");
+  if (docsDir === "src/content/docs") docsDir = parseDocsDir(source);
+  if (base === "/") base = parseBase(source);
+  if (locales.length === 0) locales = parseLocales(source);
+  const found = parseHeaderNav(source);
+  if (found.length > 0 && navPaths.length === 0) {
+    navPaths = found;
+    navSource = candidate;
+  }
+}
 
-    const candidates = slug
-      ? [join(ROOT, docsDir, slug, "index.mdx"), join(ROOT, docsDir, `${slug}.mdx`)]
-      : [join(ROOT, docsDir, "index.mdx")];
+if (navPaths.length === 0) {
+  warnings.push(
+    `[NO-NAV] no headerNav entries found in ${CONFIG_SOURCES.map((c) => relative(ROOT, c)).join(" or ")}. ` +
+      `The headerNav→suppressed-category check inspected ZERO links. If this ` +
+      `site does define a header nav, it is declared somewhere this script does ` +
+      `not look and the check is a no-op — fix the canonical script in ` +
+      `wisdom-tweaker/shared/scripts/ rather than ignoring this warning.`,
+  );
+} else {
+  notes.push(
+    `parsed ${navPaths.length} headerNav entr(ies) from ${relative(ROOT, navSource)}`,
+  );
+}
+notes.push(
+  locales.length > 0
+    ? `checking ${locales.length + 1} locale dir(s): ${docsDir}, ${locales.map((l) => l.dir).join(", ")}`
+    : `checking 1 locale dir: ${docsDir}`,
+);
 
+/** Candidate source files for a nav slug within one content dir. */
+function candidatesFor(dir, slug) {
+  const out = [];
+  for (const ext of PAGE_EXTS) {
+    if (slug) {
+      out.push(join(ROOT, dir, slug, `index${ext}`));
+      out.push(join(ROOT, dir, `${slug}${ext}`));
+    } else {
+      out.push(join(ROOT, dir, `index${ext}`));
+    }
+  }
+  return out;
+}
+
+for (const navPath of navPaths) {
+  let slug = navPath;
+  if (base && base !== "/" && slug.startsWith(base)) slug = slug.slice(base.length);
+  slug = slug.replace(/^\/+/, "").replace(/\/+$/, "");
+  if (slug === "docs") slug = "";
+  else if (slug.startsWith("docs/")) slug = slug.slice("docs/".length);
+
+  // Check the default locale and every configured locale — a suppressed JA
+  // page behind a surviving JA header link is just as much a 404.
+  const targets = [{ locale: "(default)", dir: docsDir }, ...locales];
+  let resolvedAnywhere = false;
+
+  for (const t of targets) {
     let resolved = null;
-    for (const c of candidates) {
+    for (const c of candidatesFor(t.dir, slug)) {
       if (await exists(c)) {
         resolved = c;
         break;
       }
     }
+    if (!resolved) continue;
+    resolvedAnywhere = true;
 
-    if (!resolved) {
-      warnings.push(
-        `[UNRESOLVED] headerNav "${navPath}" — could not resolve to a source ` +
-          `file under ${docsDir}/. Verify the link manually; this check could ` +
-          `not.`,
-      );
-      continue;
-    }
-
-    const fm = frontmatter(await readFile(resolved, "utf-8"));
-    if (hasNoPage(fm)) {
+    if (hasNoPage(frontmatter(await readFile(resolved, "utf-8")))) {
       failures.push(
-        `[NAV-404] headerNav "${navPath}" targets ${relative(ROOT, resolved)}, ` +
-          `which sets category_no_page: true. That page is never emitted, so ` +
-          `the header link 404s site-wide. Remove the nav entry or drop ` +
-          `category_no_page.`,
+        `[NAV-404] headerNav "${navPath}" targets ${relative(ROOT, resolved)} ` +
+          `(locale ${t.locale}), which sets category_no_page. That page is ` +
+          `never emitted, so the header link 404s. Remove the nav entry or ` +
+          `drop category_no_page.`,
       );
     }
   }
-} else {
-  warnings.push(`[NO-CONFIG] ${relative(ROOT, CONFIG)} not found — headerNav check skipped.`);
+
+  if (!resolvedAnywhere) {
+    warnings.push(
+      `[UNRESOLVED] headerNav "${navPath}" — no source file found in any ` +
+        `content dir. Verify this link manually; the check could not.`,
+    );
+  }
 }
 
 // ── Report ────────────────────────────────────────────────────────────────
+// Counts always print, so "checked nothing" can never masquerade as "all good".
+for (const n of notes) console.log(`  · ${n}`);
 for (const w of warnings) console.warn(`  ⚠️  ${w}`);
 
 if (failures.length === 0) {
-  const scanned = sidecars.length === 0 ? "no sidecars" : `${sidecars.length} sidecars`;
-  console.log(`OK — category metadata check passed (${scanned}).`);
+  console.log(`OK — category metadata check passed (${sidecars.length} sidecar(s) found).`);
   process.exit(0);
 }
 

--- a/scripts/check-pin-parity.mjs
+++ b/scripts/check-pin-parity.mjs
@@ -6,11 +6,10 @@
 // Verifies that related packages stay in lockstep within package.json.
 // Two version groups must be internally consistent:
 //
-//   zfb group (exact pins) — all four must be the same version:
+//   zfb group (exact pins) — all three must be the same version:
 //     dependencies["@takazudo/zfb"]
 //     dependencies["@takazudo/zfb-runtime"]
 //     dependencies["@takazudo/zfb-adapter-cloudflare"]
-//     dependencies["@takazudo/zfb-md-wasm"]
 //
 //   zudo-doc group (caret/tilde stripped before comparison) — all three
 //   must resolve to the same base version:
@@ -31,6 +30,14 @@ const __dirname = dirname(__filename);
 const ROOT_DIR = resolve(__dirname, "..");
 const ROOT_PKG_PATH = resolve(ROOT_DIR, "package.json");
 
+// CANONICAL COPY: wisdom-tweaker/shared/scripts/. Distributed verbatim to every
+// *-wisdom repo. Edit here, then re-sync — do not patch a single repo's copy.
+//
+// zfb-md-wasm belongs in this list: it is versioned in lockstep with the rest of
+// the zfb family and zudo-doc peer-requires it at the same range. It was omitted
+// originally, so a stale md-wasm passed the guard silently — which is exactly
+// the failure this check exists to prevent, and it went unnoticed until the
+// family moved off next.89.
 const ZFB_PACKAGES = [
   "@takazudo/zfb",
   "@takazudo/zfb-runtime",


### PR DESCRIPTION
## Summary

Re-lands the zudo-doc 4.4.13 bump that PR #58 reverted — this time moving the zfb family with it, so the bump is **peer-clean** rather than a silently tolerated peer violation. Also picks up v2 of both canonical guard scripts and gates the category-metadata lint in CI.

## 1. Canonical guard scripts re-synced (v2)

Both copied byte-for-byte from `wisdom-tweaker/shared/scripts/`:

| Script | md5 |
|---|---|
| `scripts/check-category-meta.mjs` | `6652142863ced310f422562af4f85841` |
| `scripts/check-pin-parity.mjs` | `2fd0e99eabc78fd5c3b1a53be9ddda86` |

v2 fixes the three false-green bugs found reviewing v1 — the `category_no_page` regex now accepts `True`/`TRUE` and a trailing YAML comment, locale content dirs are checked rather than only the default `docsDir`, and `ROOT` uses `fileURLToPath` instead of `URL.pathname`. It also always prints the counts it inspected, after a sibling repo produced a green `OK` having parsed **zero** `headerNav` entries.

Output here confirms the check is genuinely exercised, not vacuously passing:

```
· scanned 131 source file(s) under src/
· parsed 9 headerNav entr(ies) from zfb.config.ts
· checking 2 locale dir(s): src/content/docs, src/content/docs-ja
OK — category metadata check passed (0 sidecar(s) found).
```

Note: this repo's `check-pin-parity.mjs` **already listed all four** zfb packages, so the `zfb-md-wasm` omission that motivated the upstream fix was never present here — only comments changed.

## 2. Dependency bump (lockfile-verified)

```
@takazudo/zfb                     0.1.0-next.89 -> 0.1.0-next.99
@takazudo/zfb-runtime             0.1.0-next.89 -> 0.1.0-next.99
@takazudo/zfb-adapter-cloudflare  0.1.0-next.89 -> 0.1.0-next.99
@takazudo/zfb-md-wasm             0.1.0-next.89 -> 0.1.0-next.99
@takazudo/zudo-doc                       ^4.2.1 -> ^4.4.13
@takazudo/zudo-doc-history-server        ^4.2.1 -> ^4.4.13
create-zudo-doc (devDependency)          ^4.2.1 -> ^4.4.13
```

`@takazudo/zdtp` stays at `0.4.9`.

Because `^4.2.1` already admits `4.4.13`, an install can leave the lockfile untouched even when package.json looks right — so lockfile movement was **verified explicitly**, not inferred. `pnpm-lock.yaml` moved (+144/-69) and now resolves `zudo-doc@4.4.13` against `@takazudo/zfb@0.1.0-next.99`, satisfying the peer that the previous attempt violated.

## 3. Wrangler pin — no change needed

`check:wrangler-pin` passes unchanged: zfb `next.99` still expects wrangler `4.85.0`, same as `next.89`. Independently corroborated by `pnpm preview` starting successfully, since zfb's dev/preview path runs a hard exact-match wrangler gate.

## 4. Template drift reconcile (4.4.13 baseline)

`check:template-drift` reports zero drift — but four of the five `templates/base` files plus the sole i18n feature file are allowlisted, leaving `tsconfig.json` as the only file actually compared. Every entry was therefore re-validated against the 4.4.13 templates rather than trusting the green exit:

| File | Outcome |
|---|---|
| `src/styles/global.css` | Still diverges (brand fonts/colors) — kept |
| `pages/index.tsx` | Still diverges (reconstructed wide home) — kept |
| `pages/docs/[[...slug]].tsx` | Still diverges (docHistory patch) — kept |
| `pages/[locale]/docs/[[...slug]].tsx` | Still diverges (docHistory patch) — kept |
| `scripts/setup-doc-skill.sh` | Still diverges (skill name + Codex target) — kept |
| `tsconfig.json` | Still byte-identical — correctly unlisted |

Nothing adopted, nothing overwritten, nothing newly allowlisted. The base file set and feature dir set (`claudeSkills`, `i18n`, `tauri`, `tauriDev`) are unchanged from 4.2.1, so the feature loop still scans the right feature and needed no adjustment.

`setup-doc-skill.sh` is the only template whose *content* changed between 4.2.1 and 4.4.13 (upstream added `PROJECT_PREFIX` / `MAIN_PROJECT_DIR` nested-project and worktree correctness). Our fork has deliberately not adopted it — that is a separate piece of work from a version bump — and this is now recorded in the allowlist.

**Stale header fixed:** the allowlist claimed `pages/index.tsx` was byte-identical and unlisted. That has been false since the wide-home-page change. It was fixed once before and lost as collateral damage of the clean revert in #58; it is landed for good this time.

## 5. Category Metadata gated in CI

Adds a `Category Metadata Check` job to `pr-checks.yml`, mirroring the `Pin Parity Check` job — pure Node, no `pnpm install`, no build. Until now the lint gated only local `b4push` runs, so a push that skipped `b4push` could land a silently suppressed category or a 404ing header link.

## 6. Runtime smoke test

A 10-release zfb jump (`next.89` -> `next.99`) is not exercised by a build alone, so the running site was checked via `pnpm preview` + `/headless-browser`:

| Page | Status | Page errors | Non-font failed requests |
|---|---|---|---|
| `/` | 200 | 0 | 0 |
| `/docs/architecture/` | 200 | 0 | 0 |
| `/ja/docs/getting-started/` (locale) | 200 | 0 | 0 |

Every failed request was `fonts.gstatic.com` — sandbox-blocked Google Fonts, an environmental constraint present identically before the bump. The single console error type is that same blocked-font `ERR_FAILED`. Home and doc pages render pixel-identically to the `next.89` baseline (the home screenshot is even byte-identical at 94,117 bytes), with the wide home layout, all 9 nav entries, sidebar, TOC, and breadcrumb intact.

## Test Plan

`pnpm b4push` passes all 9 steps, no `B4PUSH_SKIP_*` overrides:

```
Step 1/9 Format check        Step 6/9 Type checking (zfb check)
Step 2/9 Category metadata   Step 7/9 Build (131 pages)
Step 3/9 Template drift      Step 8/9 HTML validation
Step 4/9 Pin parity          Step 9/9 Link check
Step 5/9 Wrangler pin
```

Pin parity confirms both groups moved in lockstep: zfb group (4 packages) = `0.1.0-next.99`, zudo-doc group (3 packages) = `4.4.13`.
