### PR TITLE
fix: restore the site's own home-hero logo (set logo: /img/logo.svg)

### DIFF
--- a/zfb.config.ts
+++ b/zfb.config.ts
@@ -20,6 +20,10 @@ export default defineConfig(
     // ── Site identity ─────────────────────────────────────────────────────
     siteName: "zudo-tauri-wisdom",
     siteDescription: "Takazudo's Tauri dev notes for me and AI agents",
+    // Must be set explicitly: zudo-doc's `logo` defaults to "auto" (4.4.0+),
+    // which renders a generated placeholder mark over this site's own banner.
+    // Omitting this line silently loses the brand asset, with a green build.
+    logo: "/img/logo.svg",
     githubUrl: "https://github.com/Takazudo/zudo-tauri-wisdom",
     siteUrl: "https://zudo-tauri-wisdom.takazudomodular.com",
     metaTags: {


### PR DESCRIPTION
## Summary

The home hero was rendering zudo-doc's generated `AutoLogo` placeholder instead of this site's own `public/img/logo.svg` banner.

zudo-doc 4.4.0 introduced a `logo` setting (`logo?: string | false`, `@default "auto"`). This repo never set it, so `HomePageView` took the `"auto"` branch and drew a generated deterministic SVG over the host's brand mark — with a completely green build. The asset itself was never touched: `public/img/logo.svg` is unchanged and still byte-identical to the copy in the sibling wisdom repos.

## Changes

- `zfb.config.ts` — add `logo: "/img/logo.svg"` to the `zudoDoc({ ... })` settings, in the Site identity block, plus a comment recording why it must be set explicitly. The upstream default is not recoverable by reading this file, so the next reader would have no way to know that omitting the line silently swaps the logo.

No other files changed. The SVG, dependencies, and config structure are untouched.

This is a restoration, not a redesign: the path-string branch renders the asset in the same box geometry the hero already used (`w-[320px] max-w-full aspect-[1200/630]`), as a theme-adaptive `bg-fg` CSS mask.

## Test Plan

`pnpm b4push` — all 9 checks pass (typecheck, build, html-validate, link check, category-meta, pin-parity, wrangler-pin, template-drift).

Rendering was verified in a real browser against the built `dist/`, at 1440 / 1600 / 700 viewports, on both `/` and `/ja/`, with viewport-sized captures (never `fullPage`).

**DOM assertions — both directions, all 6 locale x viewport combinations:**

| assertion | result |
|---|---|
| hero logo element | `div.w-[320px].max-w-full.aspect-[1200/630].bg-fg.shrink-0` |
| computed `mask-image` / `-webkit-mask-image` | `url(".../img/logo.svg")`, `contain`, `no-repeat` |
| AutoLogo `svg[data-auto-logo]` remaining in hero | **0** |
| `/img/logo.svg` over HTTP | `200`, `image/svg+xml`, 54093 bytes |
| console errors | none |

Asserting both directions matters: a mask pointing at a 404 still reports a healthy computed style, so the asset fetch is a separate fact from the CSS.

**Instrument discrimination (the control).** Before/after was captured on the same harness. First, the same build was captured twice to establish that the capture is byte-stable — otherwise a real diff could be dismissed as flake, or noise mistaken for a change:

| comparison | verdict | diff px | max channel delta |
|---|---|---|---|
| same build, captured twice (control) | IDENTICAL, all 12 images | 0 | 0 |
| before vs after, logo box @1440 | DIFFERS | 23657 (44.0% of box) | 226 |
| before vs after, full viewport @1440 | DIFFERS | 23657 (1.8% of page) | 226 |

The full-viewport diff count equals the logo-box diff count exactly (23657 = 23657), which independently confirms the change is scoped to the logo and moved nothing else on the page.

Before renders the generated placeholder (framed envelope + document glyph); after renders the bird+fish + "W" banner. Dark mode inverts correctly (logo `oklch(0.965 ...)` on page `oklch(0.185 ...)`), confirming the `bg-fg` mask is theme-adaptive rather than a fixed-colour image.

**Known, not introduced by this change:** the banner's "W" is an SVG `<text>` element requesting `Bodoni 72 Oldstyle`, a macOS system font. An SVG consumed as a CSS mask cannot load external fonts, so on Linux the W falls back to a generic serif. That is a pre-existing property of the asset and is unchanged here.